### PR TITLE
feat: add coloured output and ensure that handler received all events

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,11 +9,9 @@ edition = "2021"
 logid = { path = "../logid" }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-
-[dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 thiserror = "1.0"
 
-[[bench]]
-name = "bench"
-harness = false
+#[[bench]]
+#name = "bench"
+#harness = false

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -25,7 +25,7 @@ pub fn bench_error_tracing(c: &mut Criterion) {
 }
 
 pub fn bench_error_logid(c: &mut Criterion) {
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -35,14 +35,12 @@ pub fn bench_error_logid(c: &mut Criterion) {
     c.bench_function("logid errors", |b| {
         b.iter(|| log!(err_id, "Trace an error."))
     });
-
-    log_handler.shutdown();
 }
 
 pub fn bench_full_logid(c: &mut Criterion) {
     let _ = logid::set_filter!("trace(all)");
 
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -59,14 +57,12 @@ pub fn bench_full_logid(c: &mut Criterion) {
 
         let _: Result<(), BenchError> = err!(BenchError::Test);
     }));
-
-    log_handler.shutdown();
 }
 
 pub fn bench_compare(c: &mut Criterion) {
     tracing_subscriber::fmt::init();
 
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -84,8 +80,6 @@ pub fn bench_compare(c: &mut Criterion) {
     });
 
     bench_group.finish();
-
-    log_handler.shutdown();
 }
 
 pub fn bench_compare_advanced_logging(c: &mut Criterion) {
@@ -93,7 +87,7 @@ pub fn bench_compare_advanced_logging(c: &mut Criterion) {
 
     let _ = logid::set_filter!("debug(infos)");
 
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -105,8 +99,6 @@ pub fn bench_compare_advanced_logging(c: &mut Criterion) {
     bench_group.bench_function("logid", |b| b.iter(|| advanced_logid()));
 
     bench_group.finish();
-
-    log_handler.shutdown();
 }
 
 fn advanced_logid() -> Result<(), BenchError> {

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -7,7 +7,7 @@ use logid::{
 };
 
 fn main() {
-    let _ = logid::set_filter!("trace(id)");
+    let _ = logid::set_filter!("trace(all)");
 
     let handler = LogEventHandlerBuilder::new()
         .to_stderr()
@@ -21,11 +21,11 @@ fn main() {
 
     let start_time = std::time::Instant::now();
 
-    log!(BenchError::Test, "Logid error 1 in full bench", add: AddonKind::Info("Added info in full bench related to error trace.".to_string())
-    , add: AddonKind::Debug("Added debug info in full bench related to error trace.".to_string())
-    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
-
     let _ = bench_full_logid();
+
+    log!(BenchError::Test, "Logid error 1 in full bench\nspanning two lines", add: AddonKind::Info("Added info in full bench\nrelated to error trace.".to_string())
+    , add: AddonKind::Debug("Added debug info in full bench\nrelated to error trace.".to_string())
+    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
 
     let end_time = std::time::Instant::now();
 

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,3 +1,119 @@
+use logid::{
+    err,
+    event_handler::LogEventHandlerBuilder,
+    log,
+    logging::{event_entry::AddonKind, LOGGER},
+    DbgLogId, ErrLogId, InfoLogId, TraceLogId, WarnLogId,
+};
+
 fn main() {
-    println!("Hello, world!");
+    let _ = logid::set_filter!("trace(id)");
+
+    let handler = LogEventHandlerBuilder::new()
+        .to_stderr()
+        .all_log_events()
+        .build();
+
+    let handler2 = LogEventHandlerBuilder::new()
+        // .to_stderr()
+        .all_log_events()
+        .build();
+
+    let start_time = std::time::Instant::now();
+
+    log!(BenchError::Test, "Logid error 1 in full bench", add: AddonKind::Info("Added info in full bench related to error trace.".to_string())
+    , add: AddonKind::Debug("Added debug info in full bench related to error trace.".to_string())
+    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
+
+    let _ = bench_full_logid();
+
+    let end_time = std::time::Instant::now();
+
+    handler.stop();
+
+    log!(
+        BenchWarn::Test,
+        "Event not logged by handler, but captured."
+    );
+
+    handler.start();
+
+    log!(BenchWarn::Test, "Event logged again.");
+
+    handler2.stop();
+
+    log!(
+        BenchError::Test,
+        "Event logged => handler2.stop() does not affect handler."
+    );
+
+    LOGGER.stop_capturing();
+
+    log!(
+        BenchWarn::Test,
+        "Global logging stopped => Event not logged."
+    );
+
+    LOGGER.start_capturing();
+
+    log!(BenchWarn::Test, "Event logged again globally.");
+
+    println!(
+        "Duration: {}us\n-----------------------------\n",
+        end_time
+            .checked_duration_since(start_time)
+            .unwrap()
+            .as_micros()
+    );
+}
+
+fn bench_full_logid() -> Result<(), BenchError> {
+    log!(BenchError::Test, "Logid error 2 in full bench", add: AddonKind::Info("Added info in full bench related to error trace.".to_string())
+    , add: AddonKind::Debug("Added debug info in full bench related to error trace.".to_string())
+    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
+
+    let warn_event = log!(BenchWarn::Test, "Logid warn in full bench.");
+    let info_event = log!(
+        BenchInfo::Test,
+        "Logid info in full bench.",
+        add: AddonKind::Related(warn_event)
+    );
+    let dbg_event = log!(
+        BenchDbg::Test,
+        "Logid debug in full bench.",
+        add: AddonKind::Related(info_event)
+    );
+    log!(
+        BenchTrace::Test,
+        "Logid trace in full bench.",
+        add: AddonKind::Related(dbg_event)
+    );
+
+    err!(BenchError::Test)
+}
+
+#[derive(Debug, Clone, thiserror::Error, ErrLogId)]
+enum BenchError {
+    #[error("Some benchmark test error")]
+    Test,
+}
+
+#[derive(Debug, Clone, WarnLogId)]
+enum BenchWarn {
+    Test,
+}
+
+#[derive(Debug, Clone, InfoLogId)]
+enum BenchInfo {
+    Test,
+}
+
+#[derive(Debug, Clone, DbgLogId)]
+enum BenchDbg {
+    Test,
+}
+
+#[derive(Debug, Clone, TraceLogId)]
+enum BenchTrace {
+    Test,
 }

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -12,12 +12,14 @@ fn main() {
     let handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
-        .build();
+        .build()
+        .unwrap();
 
     let handler2 = LogEventHandlerBuilder::new()
         // .to_stderr()
         .all_log_events()
-        .build();
+        .build()
+        .unwrap();
 
     let start_time = std::time::Instant::now();
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { path = "../../evident", version = "0.9" }
+evident = { version = "0.10" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { version = "0.9" }
+evident = { path = "../../evident", version = "0.9" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/src/log_id.rs
+++ b/core/src/log_id.rs
@@ -13,13 +13,29 @@ pub struct LogId {
 
 impl evident::publisher::Id for LogId {}
 
-impl evident::publisher::StopCapturing for LogId {
-    fn stop_capturing(id: &Self) -> bool {
+impl evident::publisher::CaptureControl for LogId {
+    fn start(id: &Self) -> bool {
+        id == &START_LOGGING
+    }
+
+    fn start_id() -> Self {
+        START_LOGGING
+    }
+
+    fn stop(id: &Self) -> bool {
         id == &STOP_LOGGING
+    }
+
+    fn stop_id() -> Self {
+        STOP_LOGGING
     }
 }
 
-/// Notify listeners to stop logging.
+/// Notify LOGGER and listeners to start logging.
+///
+/// **Note:** Filter does not affect capturing of this LogId. It is up to the handler to decide wether to filter it or not.
+pub const START_LOGGING: LogId = crate::new_log_id!("START_LOGGING", LogLevel::Info);
+/// Notify LOGGER and listeners to stop logging.
 ///
 /// **Note:** Filter does not affect capturing of this LogId. It is up to the handler to decide wether to filter it or not.
 pub const STOP_LOGGING: LogId = crate::new_log_id!("STOP_LOGGING", LogLevel::Info);
@@ -109,7 +125,7 @@ impl std::fmt::Display for LogLevel {
 /// ```
 #[macro_export]
 macro_rules! new_log_id {
-    ($identifier:literal, $log_level:expr) => {
+    ($identifier:expr, $log_level:expr) => {
         $crate::log_id::LogId::new(
             env!("CARGO_PKG_NAME"),
             module_path!(),

--- a/core/src/logging/mod.rs
+++ b/core/src/logging/mod.rs
@@ -19,6 +19,6 @@ evident::create_static_publisher!(
     filter_type = LogFilter,
     filter = LogFilter::new(),
     capture_channel_bound = 1000,
-    subscription_channel_bound = 500,
-    non_blocking = true
+    subscription_channel_bound = 1000,
+    capture_mode = evident::publisher::CaptureMode::Blocking
 );

--- a/logid/Cargo.toml
+++ b/logid/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools::debugging"]
 [dependencies]
 logid-core = { path = "../core", version = "0" }
 logid-derive = { path = "../derive", version = "0" }
+colored = "2"
 
 [features]
 diagnostics = ["logid-core/diagnostics"]


### PR DESCRIPTION
This PR was intended to add coloured output only, but while implementing, I noticed that not all events are consistently output to the console.

The cause for missing events was a combination of thread spawning, acquiring write locks, and order of thread execution when creating a new `LogEventHandler`.  
To output logs, a new thread is spawned when building the handler. Up to now, the subscription to the global LOGGER was created inside the new thread. This caused a context switch in the new thread, because adding a subscription needs a write lock on the internal hashmap. Due to this context switch, it could happen that the main thread would resume execution, and in the test project no further context switch occurred in main, so the new thread was never rescheduled, and then destroyed after main exited.

Finding the cause took time, and while debugging I made some fundamental changes to better handle event capturing in general.

So this PR not only adds coloured output, but also adds the possibility to stop/start capturing either globally, or per handler.
' Drop'  is also implemented on 'LogEventHandler' to ensure the created thread also finishes.

About colouring, the following image shows nearly all available outputted information:

![image](https://github.com/mhatzl/logid/assets/49341624/c8cee703-7269-46a8-a215-63396889e815)
