### PR TITLE
feat: move debug & trace events behind feature flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Cargo.lock
 
 /target
 /Cargo.lock
+
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "rust-analyzer.showUnlinkedFileNotification": false
-}

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,6 +12,6 @@ tracing-subscriber = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 thiserror = "1.0"
 
-#[[bench]]
-#name = "bench"
-#harness = false
+[[bench]]
+name = "bench"
+harness = false

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,11 +9,9 @@ edition = "2021"
 logid = { path = "../logid" }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-
-[dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 thiserror = "1.0"
 
-[[bench]]
-name = "bench"
-harness = false
+#[[bench]]
+#name = "bench"
+#harness = false

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-logid = { path = "../logid" }
+logid = { path = "../logid", features = ["log_debugs"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -25,7 +25,7 @@ pub fn bench_error_tracing(c: &mut Criterion) {
 }
 
 pub fn bench_error_logid(c: &mut Criterion) {
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -35,14 +35,12 @@ pub fn bench_error_logid(c: &mut Criterion) {
     c.bench_function("logid errors", |b| {
         b.iter(|| log!(err_id, "Trace an error."))
     });
-
-    log_handler.shutdown();
 }
 
 pub fn bench_full_logid(c: &mut Criterion) {
     let _ = logid::set_filter!("trace(all)");
 
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -59,14 +57,12 @@ pub fn bench_full_logid(c: &mut Criterion) {
 
         let _: Result<(), BenchError> = err!(BenchError::Test);
     }));
-
-    log_handler.shutdown();
 }
 
 pub fn bench_compare(c: &mut Criterion) {
     tracing_subscriber::fmt::init();
 
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -84,8 +80,6 @@ pub fn bench_compare(c: &mut Criterion) {
     });
 
     bench_group.finish();
-
-    log_handler.shutdown();
 }
 
 pub fn bench_compare_advanced_logging(c: &mut Criterion) {
@@ -93,7 +87,7 @@ pub fn bench_compare_advanced_logging(c: &mut Criterion) {
 
     let _ = logid::set_filter!("debug(infos)");
 
-    let log_handler = LogEventHandlerBuilder::new()
+    let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
         .build();
@@ -105,8 +99,6 @@ pub fn bench_compare_advanced_logging(c: &mut Criterion) {
     bench_group.bench_function("logid", |b| b.iter(|| advanced_logid()));
 
     bench_group.finish();
-
-    log_handler.shutdown();
 }
 
 fn advanced_logid() -> Result<(), BenchError> {

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -9,7 +9,7 @@ use tracing::metadata::LevelFilter;
 
 criterion_main!(benches);
 // criterion_group!(benches, bench_compare);
-criterion_group!(benches, bench_compare_advanced_logging);
+criterion_group!(benches, bench_compare_advanced_logging, bench_error_logid);
 
 pub fn bench_error_tracing(c: &mut Criterion) {
     tracing_subscriber::fmt::init();
@@ -57,10 +57,10 @@ pub fn bench_compare(c: &mut Criterion) {
 
 pub fn bench_compare_advanced_logging(c: &mut Criterion) {
     tracing_subscriber::fmt::fmt()
-        .with_max_level(LevelFilter::TRACE)
+        .with_max_level(LevelFilter::DEBUG)
         .init();
 
-    let _ = logid::set_filter!("trace(infos)");
+    let _ = logid::set_filter!("debug(infos)");
 
     let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -1,20 +1,15 @@
-// use criterion::{criterion_group, criterion_main};
 use criterion::{black_box, Criterion};
+use criterion::{criterion_group, criterion_main};
+use logid::logging::LOGGER;
 use logid::{
     err, event_handler::LogEventHandlerBuilder, log, log_id::LogLevel,
     logging::event_entry::AddonKind, DbgLogId, ErrLogId, InfoLogId, TraceLogId, WarnLogId,
 };
+use tracing::metadata::LevelFilter;
 
-// criterion_main!(benches);
-// criterion_group!(benches, bench_compare_advanced_logging);
-// criterion_group!(
-//     name = benches;
-//     config = Criterion::default()
-//         .sample_size(10)
-//         .warm_up_time(std::time::Duration::from_millis(1))
-//         .measurement_time(std::time::Duration::from_millis(700));
-//     targets = bench_full_logid
-// );
+criterion_main!(benches);
+// criterion_group!(benches, bench_compare);
+criterion_group!(benches, bench_compare_advanced_logging);
 
 pub fn bench_error_tracing(c: &mut Criterion) {
     tracing_subscriber::fmt::init();
@@ -35,28 +30,6 @@ pub fn bench_error_logid(c: &mut Criterion) {
     c.bench_function("logid errors", |b| {
         b.iter(|| log!(err_id, "Trace an error."))
     });
-}
-
-pub fn bench_full_logid(c: &mut Criterion) {
-    let _ = logid::set_filter!("trace(all)");
-
-    let _log_handler = LogEventHandlerBuilder::new()
-        .to_stderr()
-        .all_log_events()
-        .build();
-
-    c.bench_function("full logid", |b| b.iter(|| {
-        log!(BenchError::Test, black_box("Logid error in full bench."), add: AddonKind::Info(black_box("Added info in full bench related to error trace.").to_string())
-        , add: AddonKind::Debug(black_box("Added debug info in full bench related to error trace.").to_string())
-        , add: AddonKind::Trace(black_box("Added trace info in full bench related to error trace.").to_string()));
-
-        let warn_event = log!(BenchWarn::Test, black_box("Logid warn in full bench."));
-        let info_event = log!(BenchInfo::Test, black_box("Logid info in full bench."), add: AddonKind::Related(warn_event));
-        let dbg_event = log!(BenchDbg::Test, black_box("Logid debug in full bench."), add: AddonKind::Related(info_event));
-        log!(BenchTrace::Test, black_box("Logid trace in full bench."), add: AddonKind::Related(dbg_event));
-
-        let _: Result<(), BenchError> = err!(BenchError::Test);
-    }));
 }
 
 pub fn bench_compare(c: &mut Criterion) {
@@ -83,9 +56,11 @@ pub fn bench_compare(c: &mut Criterion) {
 }
 
 pub fn bench_compare_advanced_logging(c: &mut Criterion) {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt::fmt()
+        .with_max_level(LevelFilter::TRACE)
+        .init();
 
-    let _ = logid::set_filter!("debug(infos)");
+    let _ = logid::set_filter!("trace(infos)");
 
     let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()
@@ -99,28 +74,38 @@ pub fn bench_compare_advanced_logging(c: &mut Criterion) {
     bench_group.bench_function("logid", |b| b.iter(|| advanced_logid()));
 
     bench_group.finish();
+
+    println!(
+        "-----------------------------------------------------------------------\nMissed logs: {}",
+        LOGGER.get_missed_captures()
+    );
 }
 
 fn advanced_logid() -> Result<(), BenchError> {
-    log!(BenchError::Test, black_box("Logid error in advanced bench."), add: AddonKind::Info(black_box("Trace info in advanced bench related to error trace.").to_string()));
+    log!(BenchError::Test, black_box("Logid error in advanced bench."), add: AddonKind::Info(black_box("Logid info in advanced bench related to error trace.").to_string()));
 
     log!(BenchWarn::Test, black_box("Logid warn in advanced bench."));
     log!(BenchInfo::Test, black_box("Logid info in advanced bench."));
     log!(BenchDbg::Test, black_box("Logid debug in advanced bench."));
+    log!(
+        BenchTrace::Test,
+        black_box("Logid trace in advanced bench.")
+    );
 
     err!(BenchError::Test)
 }
 
 fn advanced_tracing() -> Result<(), BenchError> {
-    tracing::error!("{}", black_box("Trace error in advanced bench."));
+    tracing::error!("{}", black_box("Tracing error in advanced bench."));
     tracing::info!(
         "{}",
-        black_box("|--> Info: Trace info in advanced bench related to error trace.")
+        black_box("|--> Info: Tracing info in advanced bench related to error trace.")
     );
 
-    tracing::warn!("{}", black_box("Trace warn in advanced bench."));
-    tracing::info!("{}", black_box("Trace info in advanced bench."));
-    tracing::debug!("{}", black_box("Trace debug in advanced bench."));
+    tracing::warn!("{}", black_box("Tracing warn in advanced bench."));
+    tracing::info!("{}", black_box("Tracing info in advanced bench."));
+    tracing::debug!("{}", black_box("Tracing debug in advanced bench."));
+    tracing::trace!("{}", black_box("Tracing trace in advanced bench."));
 
     Err({
         tracing::error!("{}", black_box(BenchError::Test.to_string()));

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -7,7 +7,7 @@ use logid::{
 };
 
 fn main() {
-    let _ = logid::set_filter!("trace(id)");
+    let _ = logid::set_filter!("trace(all)");
 
     let handler = LogEventHandlerBuilder::new()
         .to_stderr()
@@ -21,11 +21,11 @@ fn main() {
 
     let start_time = std::time::Instant::now();
 
-    log!(BenchError::Test, "Logid error 1 in full bench", add: AddonKind::Info("Added info in full bench related to error trace.".to_string())
-    , add: AddonKind::Debug("Added debug info in full bench related to error trace.".to_string())
-    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
-
     let _ = bench_full_logid();
+
+    log!(BenchError::Test, "Logid error 1 in full bench\nspanning two lines", add: AddonKind::Info("Added info in full bench\nrelated to error trace.".to_string())
+    , add: AddonKind::Debug("Added debug info in full bench\nrelated to error trace.".to_string())
+    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
 
     let end_time = std::time::Instant::now();
 

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,3 +1,119 @@
+use logid::{
+    err,
+    event_handler::LogEventHandlerBuilder,
+    log,
+    logging::{event_entry::AddonKind, LOGGER},
+    DbgLogId, ErrLogId, InfoLogId, TraceLogId, WarnLogId,
+};
+
 fn main() {
-    println!("Hello, world!");
+    let _ = logid::set_filter!("trace(id)");
+
+    let handler = LogEventHandlerBuilder::new()
+        .to_stderr()
+        .all_log_events()
+        .build();
+
+    let handler2 = LogEventHandlerBuilder::new()
+        // .to_stderr()
+        .all_log_events()
+        .build();
+
+    let start_time = std::time::Instant::now();
+
+    log!(BenchError::Test, "Logid error 1 in full bench", add: AddonKind::Info("Added info in full bench related to error trace.".to_string())
+    , add: AddonKind::Debug("Added debug info in full bench related to error trace.".to_string())
+    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
+
+    let _ = bench_full_logid();
+
+    let end_time = std::time::Instant::now();
+
+    handler.stop();
+
+    log!(
+        BenchWarn::Test,
+        "Event not logged by handler, but captured."
+    );
+
+    handler.start();
+
+    log!(BenchWarn::Test, "Event logged again.");
+
+    handler2.stop();
+
+    log!(
+        BenchError::Test,
+        "Event logged => handler2.stop() does not affect handler."
+    );
+
+    LOGGER.stop_capturing();
+
+    log!(
+        BenchWarn::Test,
+        "Global logging stopped => Event not logged."
+    );
+
+    LOGGER.start_capturing();
+
+    log!(BenchWarn::Test, "Event logged again globally.");
+
+    println!(
+        "Duration: {}us\n-----------------------------\n",
+        end_time
+            .checked_duration_since(start_time)
+            .unwrap()
+            .as_micros()
+    );
+}
+
+fn bench_full_logid() -> Result<(), BenchError> {
+    log!(BenchError::Test, "Logid error 2 in full bench", add: AddonKind::Info("Added info in full bench related to error trace.".to_string())
+    , add: AddonKind::Debug("Added debug info in full bench related to error trace.".to_string())
+    , add: AddonKind::Trace("Added trace info in full bench related to error trace.".to_string()));
+
+    let warn_event = log!(BenchWarn::Test, "Logid warn in full bench.");
+    let info_event = log!(
+        BenchInfo::Test,
+        "Logid info in full bench.",
+        add: AddonKind::Related(warn_event)
+    );
+    let dbg_event = log!(
+        BenchDbg::Test,
+        "Logid debug in full bench.",
+        add: AddonKind::Related(info_event)
+    );
+    log!(
+        BenchTrace::Test,
+        "Logid trace in full bench.",
+        add: AddonKind::Related(dbg_event)
+    );
+
+    err!(BenchError::Test)
+}
+
+#[derive(Debug, Clone, thiserror::Error, ErrLogId)]
+enum BenchError {
+    #[error("Some benchmark test error")]
+    Test,
+}
+
+#[derive(Debug, Clone, WarnLogId)]
+enum BenchWarn {
+    Test,
+}
+
+#[derive(Debug, Clone, InfoLogId)]
+enum BenchInfo {
+    Test,
+}
+
+#[derive(Debug, Clone, DbgLogId)]
+enum BenchDbg {
+    Test,
+}
+
+#[derive(Debug, Clone, TraceLogId)]
+enum BenchTrace {
+    Test,
 }

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -12,12 +12,14 @@ fn main() {
     let handler = LogEventHandlerBuilder::new()
         .to_stderr()
         .all_log_events()
-        .build();
+        .build()
+        .unwrap();
 
     let handler2 = LogEventHandlerBuilder::new()
         // .to_stderr()
         .all_log_events()
-        .build();
+        .build()
+        .unwrap();
 
     let start_time = std::time::Instant::now();
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,4 +17,6 @@ serde_json = { version = "1.0", optional = true }
 [features]
 diagnostics = ["lsp-types"]
 payloads = ["serde_json"]
+log_debugs = []
+log_traces = []
 test_filter = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { path = "../../evident", version = "0.9" }
+evident = { version = "0.10" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { version = "0.10" }
+evident = { path = "../../evident", version = "0.11" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { version = "0.9" }
+evident = { path = "../../evident", version = "0.9" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { path = "../../evident", version = "0.11" }
+evident = { version = "0.11" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/src/log_id.rs
+++ b/core/src/log_id.rs
@@ -13,13 +13,29 @@ pub struct LogId {
 
 impl evident::publisher::Id for LogId {}
 
-impl evident::publisher::StopCapturing for LogId {
-    fn stop_capturing(id: &Self) -> bool {
+impl evident::publisher::CaptureControl for LogId {
+    fn start(id: &Self) -> bool {
+        id == &START_LOGGING
+    }
+
+    fn start_id() -> Self {
+        START_LOGGING
+    }
+
+    fn stop(id: &Self) -> bool {
         id == &STOP_LOGGING
+    }
+
+    fn stop_id() -> Self {
+        STOP_LOGGING
     }
 }
 
-/// Notify listeners to stop logging.
+/// Notify LOGGER and listeners to start logging.
+///
+/// **Note:** Filter does not affect capturing of this LogId. It is up to the handler to decide wether to filter it or not.
+pub const START_LOGGING: LogId = crate::new_log_id!("START_LOGGING", LogLevel::Info);
+/// Notify LOGGER and listeners to stop logging.
 ///
 /// **Note:** Filter does not affect capturing of this LogId. It is up to the handler to decide wether to filter it or not.
 pub const STOP_LOGGING: LogId = crate::new_log_id!("STOP_LOGGING", LogLevel::Info);
@@ -109,7 +125,7 @@ impl std::fmt::Display for LogLevel {
 /// ```
 #[macro_export]
 macro_rules! new_log_id {
-    ($identifier:literal, $log_level:expr) => {
+    ($identifier:expr, $log_level:expr) => {
         $crate::log_id::LogId::new(
             env!("CARGO_PKG_NAME"),
             module_path!(),

--- a/core/src/log_id.rs
+++ b/core/src/log_id.rs
@@ -82,7 +82,7 @@ impl std::fmt::Display for LogId {
 }
 
 /// Log level a [`LogId`] may represent.
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, std::hash::Hash)]
+#[derive(Debug, Default, PartialOrd, PartialEq, Eq, Clone, Copy, std::hash::Hash)]
 pub enum LogLevel {
     Error = 0,
     Warn = 1,
@@ -90,12 +90,6 @@ pub enum LogLevel {
     #[default]
     Debug = 3,
     Trace = 4,
-}
-
-impl PartialOrd<LogLevel> for LogLevel {
-    fn partial_cmp(&self, other: &LogLevel) -> Option<std::cmp::Ordering> {
-        Some((*self as isize).cmp(&(*other as isize)))
-    }
 }
 
 impl std::fmt::Display for LogLevel {

--- a/core/src/logging/filter.rs
+++ b/core/src/logging/filter.rs
@@ -63,10 +63,7 @@ fn filter_config() -> String {
 }
 
 impl evident::event::filter::Filter<LogId, LogEventEntry> for LogFilter {
-    fn allow_event(
-        &self,
-        event: &mut impl evident::event::intermediary::IntermediaryEvent<LogId, LogEventEntry>,
-    ) -> bool {
+    fn allow_event(&self, event: &evident::event::Event<LogId, LogEventEntry>) -> bool {
         match self.filter.read() {
             Ok(locked_filter) => locked_filter.allow_event(event),
             Err(_) => false,
@@ -441,10 +438,7 @@ impl InnerLogFilter {
 }
 
 impl evident::event::filter::Filter<LogId, LogEventEntry> for InnerLogFilter {
-    fn allow_event(
-        &self,
-        event: &mut impl evident::event::intermediary::IntermediaryEvent<LogId, LogEventEntry>,
-    ) -> bool {
+    fn allow_event(&self, event: &evident::event::Event<LogId, LogEventEntry>) -> bool {
         // Note: event handler creates unique LogIds per handler => filter on origin
         if event
             .get_entry()

--- a/core/src/logging/mod.rs
+++ b/core/src/logging/mod.rs
@@ -20,5 +20,6 @@ evident::create_static_publisher!(
     filter = LogFilter::new(),
     capture_channel_bound = 1000,
     subscription_channel_bound = 1000,
-    capture_mode = evident::publisher::CaptureMode::Blocking
+    capture_mode = evident::publisher::CaptureMode::Blocking,
+    timestamp_kind = evident::publisher::EventTimestampKind::Captured
 );

--- a/core/src/logging/mod.rs
+++ b/core/src/logging/mod.rs
@@ -19,6 +19,6 @@ evident::create_static_publisher!(
     filter_type = LogFilter,
     filter = LogFilter::new(),
     capture_channel_bound = 1000,
-    subscription_channel_bound = 500,
-    non_blocking = true
+    subscription_channel_bound = 1000,
+    capture_mode = evident::publisher::CaptureMode::Blocking
 );

--- a/core/src/logging/tests/filter/addons.rs
+++ b/core/src/logging/tests/filter/addons.rs
@@ -2,6 +2,7 @@ use crate::{
     log_id::LogLevel,
     logging::{
         event_entry::AddonKind, filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent,
+        tests::filter::test_event,
     },
     new_log_id,
 };
@@ -20,9 +21,8 @@ fn allow_single_id_with_infos_addon() {
         log_id.get_identifier()
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
@@ -46,9 +46,8 @@ fn allow_single_id_with_infos_and_origin_addon() {
         log_id.get_identifier()
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
@@ -77,13 +76,13 @@ fn allow_single_id_with_related_addon() {
         log_id.get_identifier()
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
-    let finalized = log_event.finalize();
 
+    let log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
+    let finalized = log_event.finalize();
     assert!(
         filter.allow_addon(log_id, &this_origin!(), &AddonKind::Related(finalized)),
         "Related addon not allowed by filter."
@@ -100,9 +99,8 @@ fn allow_single_id_with_all_addons() {
         log_id.get_identifier()
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
@@ -144,9 +142,8 @@ fn allow_module_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
     let filter = InnerLogFilter::new("logid-core::logid_core(infos) = error");
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Error level not allowed by filter."
     );
 
@@ -165,9 +162,8 @@ fn allow_crate_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
     let filter = InnerLogFilter::new("logid-core::logid_core(infos) = error");
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Error level not allowed by filter."
     );
 
@@ -186,9 +182,8 @@ fn allow_general_level_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
     let filter = InnerLogFilter::new("error(infos)");
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Error level not allowed by filter."
     );
 

--- a/core/src/logging/tests/filter/global_ids.rs
+++ b/core/src/logging/tests/filter/global_ids.rs
@@ -1,12 +1,9 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent},
+    logging::{filter::InnerLogFilter, tests::filter::test_event},
     new_log_id,
 };
-use evident::{
-    event::{filter::Filter, intermediary::IntermediaryEvent},
-    this_origin,
-};
+use evident::{event::filter::Filter, this_origin};
 
 #[test]
 fn allow_single_id() {
@@ -18,9 +15,8 @@ fn allow_single_id() {
         log_id.get_identifier()
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 }
@@ -40,15 +36,13 @@ fn allow_multiple_ids() {
         log_id_2.get_identifier()
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id_1, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id_1, this_origin!())),
         "Explicitly allowed first LogId not allowed by filter."
     );
 
-    let mut log_event = IntermediaryLogEvent::new(log_id_2, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id_2, this_origin!())),
         "Explicitly allowed second LogId not allowed by filter."
     );
 }
@@ -64,9 +58,8 @@ fn invalid_ids_syntax() {
         log_id.get_identifier(),
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut log_event),
+        !filter.allow_event(&test_event(log_id, this_origin!())),
         "Invalid filter syntax allowed LogId by filter."
     );
 }

--- a/core/src/logging/tests/filter/mod.rs
+++ b/core/src/logging/tests/filter/mod.rs
@@ -1,5 +1,16 @@
+use evident::event::{intermediary::IntermediaryEvent, origin::Origin, Event};
+
+use crate::{
+    log_id::LogId,
+    logging::{event_entry::LogEventEntry, intermediary_event::IntermediaryLogEvent},
+};
+
 pub mod addons;
 pub mod global_ids;
 pub mod only_general;
 pub mod only_module;
 pub mod rule_mix;
+
+fn test_event(log_id: LogId, origin: Origin) -> Event<LogId, LogEventEntry> {
+    Event::new(IntermediaryLogEvent::new(log_id, "", origin).take_entry())
+}

--- a/core/src/logging/tests/filter/only_general.rs
+++ b/core/src/logging/tests/filter/only_general.rs
@@ -1,21 +1,18 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent},
+    logging::{filter::InnerLogFilter, tests::filter::test_event},
     new_log_id,
 };
-use evident::{
-    event::{filter::Filter, intermediary::IntermediaryEvent},
-    this_origin,
-};
+use evident::{event::filter::Filter, this_origin};
 
 #[test]
 fn logging_turned_off() {
     let filter = InnerLogFilter::new("off");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
+
     assert!(
-        !filter.allow_event(&mut error_event),
+        !filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId allowed by filter."
     );
 }
@@ -25,9 +22,9 @@ fn empty_filter_means_logging_turned_off() {
     let filter = InnerLogFilter::new("");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
+
     assert!(
-        !filter.allow_event(&mut error_event),
+        !filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId allowed by filter."
     );
 }
@@ -37,16 +34,14 @@ fn only_allow_error() {
     let filter = InnerLogFilter::new("error");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut error_event),
+        filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut warn_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut warn_event),
+        !filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId allowed by filter."
     );
 }
@@ -56,23 +51,20 @@ fn allow_error_and_warning() {
     let filter = InnerLogFilter::new("warn");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut error_event),
+        filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut warn_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut warn_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut info_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut info_event),
+        !filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -82,30 +74,26 @@ fn allow_error_warning_and_info() {
     let filter = InnerLogFilter::new("info");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut error_event),
+        filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut warn_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut warn_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut info_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut info_event),
+        filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
-    let mut debug_event = IntermediaryLogEvent::new(debug_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut debug_event),
+        !filter.allow_event(&test_event(debug_id, this_origin!())),
         "Debug level LogId allowed by filter."
     );
 }
@@ -115,37 +103,32 @@ fn allow_error_warning_info_and_debug() {
     let filter = InnerLogFilter::new("debug");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut error_event),
+        filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut warn_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut warn_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut info_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut info_event),
+        filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
-    let mut debug_event = IntermediaryLogEvent::new(debug_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut debug_event),
+        filter.allow_event(&test_event(debug_id, this_origin!())),
         "Debug level LogId not allowed by filter."
     );
 
     let trace_id = new_log_id!("trace_id", LogLevel::Trace);
-    let mut trace_event = IntermediaryLogEvent::new(trace_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut trace_event),
+        !filter.allow_event(&test_event(trace_id, this_origin!())),
         "Trace level LogId allowed by filter."
     );
 }
@@ -155,37 +138,32 @@ fn allow_error_warning_info_debug_and_trace() {
     let filter = InnerLogFilter::new("trace");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut error_event),
+        filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut warn_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut warn_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut info_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut info_event),
+        filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
-    let mut debug_event = IntermediaryLogEvent::new(debug_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut debug_event),
+        filter.allow_event(&test_event(debug_id, this_origin!())),
         "Debug level LogId not allowed by filter."
     );
 
     let trace_id = new_log_id!("trace_id", LogLevel::Trace);
-    let mut trace_event = IntermediaryLogEvent::new(trace_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut trace_event),
+        filter.allow_event(&test_event(trace_id, this_origin!())),
         "Trace level LogId not allowed by filter."
     );
 }
@@ -195,37 +173,32 @@ fn logging_on_equal_to_trace() {
     let filter = InnerLogFilter::new("on");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
-    let mut error_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut error_event),
+        filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut warn_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut warn_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut info_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut info_event),
+        filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
-    let mut debug_event = IntermediaryLogEvent::new(debug_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut debug_event),
+        filter.allow_event(&test_event(debug_id, this_origin!())),
         "Debug level LogId not allowed by filter."
     );
 
     let trace_id = new_log_id!("trace_id", LogLevel::Trace);
-    let mut trace_event = IntermediaryLogEvent::new(trace_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut trace_event),
+        filter.allow_event(&test_event(trace_id, this_origin!())),
         "Trace level LogId not allowed by filter."
     );
 }

--- a/core/src/logging/tests/filter/only_module.rs
+++ b/core/src/logging/tests/filter/only_module.rs
@@ -1,28 +1,23 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent},
+    logging::{filter::InnerLogFilter, tests::filter::test_event},
     new_log_id,
 };
-use evident::{
-    event::{filter::Filter, intermediary::IntermediaryEvent},
-    this_origin,
-};
+use evident::{event::filter::Filter, this_origin};
 
 #[test]
 fn single_module() {
     let filter = InnerLogFilter::new("logid-core::logid_core::logging = warn");
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut log_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut log_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut log_event),
+        !filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -32,16 +27,14 @@ fn only_crate_name() {
     let filter = InnerLogFilter::new("logid-core = warn");
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut log_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut log_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut log_event),
+        !filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -53,16 +46,14 @@ fn multiple_modules() {
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut log_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut log_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut log_event),
+        !filter.allow_event(&test_event(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -74,16 +65,14 @@ fn module_with_id() {
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
-    let mut log_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut log_event),
+        !filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level LogId allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut log_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(info_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 }
@@ -95,16 +84,14 @@ fn module_with_id_allowed_only() {
     );
 
     let error_id = new_log_id!("error_id", LogLevel::Error);
-    let mut log_event = IntermediaryLogEvent::new(error_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut log_event),
+        !filter.allow_event(&test_event(error_id, this_origin!())),
         "Error level LogId allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
-    let mut log_event = IntermediaryLogEvent::new(info_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(info_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 }

--- a/core/src/logging/tests/filter/rule_mix.rs
+++ b/core/src/logging/tests/filter/rule_mix.rs
@@ -1,12 +1,9 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent},
+    logging::{filter::InnerLogFilter, tests::filter::test_event},
     new_log_id,
 };
-use evident::{
-    event::{filter::Filter, intermediary::IntermediaryEvent},
-    this_origin,
-};
+use evident::{event::filter::Filter, this_origin};
 
 #[test]
 fn global_id_and_general_error() {
@@ -21,21 +18,18 @@ fn global_id_and_general_error() {
         log_id.get_identifier()
     ));
 
-    let mut log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
-    let mut log_event = IntermediaryLogEvent::new(err_id, "", this_origin!());
     assert!(
-        filter.allow_event(&mut log_event),
+        filter.allow_event(&test_event(err_id, this_origin!())),
         "Error level not allowed by filter."
     );
 
-    let mut log_event = IntermediaryLogEvent::new(warn_id, "", this_origin!());
     assert!(
-        !filter.allow_event(&mut log_event),
+        !filter.allow_event(&test_event(warn_id, this_origin!())),
         "Warn level allowed by filter."
     );
 }

--- a/logid/Cargo.toml
+++ b/logid/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools::debugging"]
 [dependencies]
 logid-core = { path = "../core", version = "0" }
 logid-derive = { path = "../derive", version = "0" }
+colored = "2"
 
 [features]
 diagnostics = ["logid-core/diagnostics"]

--- a/logid/Cargo.toml
+++ b/logid/Cargo.toml
@@ -19,6 +19,8 @@ colored = "2"
 [features]
 diagnostics = ["logid-core/diagnostics"]
 payloads = ["logid-core/payloads"]
+log_debugs = ["logid-core/log_debugs"]
+log_traces = ["logid-core/log_traces"]
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/logid/Cargo.toml
+++ b/logid/Cargo.toml
@@ -26,4 +26,4 @@ log_traces = ["logid-core/log_traces"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-logid-core = { path = "../core", version = "0", features = ["test_filter"] }
+logid-core = { path = "../core", version = "0", features = ["log_debugs", "log_traces", "test_filter"] }

--- a/logid/tests/panic_hook.rs
+++ b/logid/tests/panic_hook.rs
@@ -63,7 +63,7 @@ mod panic_hook_tests {
         dbg!(event.get_entry());
 
         assert_eq!(
-            *event.get_id(),
+            *event.get_event_id(),
             std::convert::Into::<LogId>::into(CriticalInfo::Panic),
             "Received event has wrong LogId."
         );


### PR DESCRIPTION
This adds two features `log_debugs` and `log_traces`.
Projects not using those features won't capture debug/trace logs.

This is a useful addition to the filter to get early returns for debug and trace events without the need to check all filter options.