### PR TITLE
feat: add hint/note addons

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-logid = { path = "../logid", features = ["log_debugs"] }
+logid = { path = "../logid", features = ["log_debugs", "log_traces", "hint_note"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -78,7 +78,9 @@ fn bench_full_logid() -> Result<(), BenchError> {
     let info_event = log!(
         BenchInfo::Test,
         "Logid info in full bench.",
-        add: AddonKind::Related(warn_event)
+        add: AddonKind::Related(warn_event),
+        add: AddonKind::Hint("Some hint".to_string()),
+        add: AddonKind::Note("Some note".to_string())
     );
     let dbg_event = log!(
         BenchDbg::Test,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { version = "1.0", optional = true }
 [features]
 diagnostics = ["lsp-types"]
 payloads = ["serde_json"]
+hint_note = []
 log_debugs = []
 log_traces = []
 test_filter = []

--- a/core/src/logging/event_entry.rs
+++ b/core/src/logging/event_entry.rs
@@ -22,6 +22,13 @@ pub struct LogEventEntry {
     /// Code position where the log-id entry was created
     pub(crate) origin: Origin,
 
+    /// List of hints for this log-id entry
+    #[cfg(feature = "hint_note")]
+    pub(crate) hints: Vec<String>,
+    /// List of notes for this log-id entry
+    #[cfg(feature = "hint_note")]
+    pub(crate) notes: Vec<String>,
+
     /// List of diagnostics for this log-id entry
     #[cfg(feature = "diagnostics")]
     pub(crate) diagnostics: Vec<crate::lsp_types::Diagnostic>,
@@ -42,6 +49,11 @@ impl crate::evident::event::entry::EventEntry<LogId> for LogEventEntry {
             traces: Vec::new(),
             related: Vec::new(),
             origin,
+
+            #[cfg(feature = "hint_note")]
+            hints: Vec::new(),
+            #[cfg(feature = "hint_note")]
+            notes: Vec::new(),
 
             #[cfg(feature = "diagnostics")]
             diagnostics: Vec::new(),
@@ -108,6 +120,16 @@ impl LogEventEntry {
         &self.related
     }
 
+    #[cfg(feature = "hint_note")]
+    pub fn get_hints(&self) -> &Vec<String> {
+        &self.hints
+    }
+
+    #[cfg(feature = "hint_note")]
+    pub fn get_notes(&self) -> &Vec<String> {
+        &self.notes
+    }
+
     #[cfg(feature = "diagnostics")]
     pub fn get_diagnostics(&self) -> &Vec<crate::lsp_types::Diagnostic> {
         &self.diagnostics
@@ -126,6 +148,11 @@ pub enum AddonKind {
     Debug(String),
     Trace(String),
     Related(FinalizedEvent<LogId>),
+
+    #[cfg(feature = "hint_note")]
+    Hint(String),
+    #[cfg(feature = "hint_note")]
+    Note(String),
 
     #[cfg(feature = "diagnostics")]
     Diagnostic(crate::lsp_types::Diagnostic),

--- a/core/src/logging/filter.rs
+++ b/core/src/logging/filter.rs
@@ -111,6 +111,11 @@ pub enum AddonFilter {
     Related,
     AllAllowed,
 
+    #[cfg(feature = "hint_note")]
+    Hint,
+    #[cfg(feature = "hint_note")]
+    Note,
+
     #[cfg(feature = "diagnostics")]
     Diagnostics,
 
@@ -125,6 +130,11 @@ impl From<&AddonKind> for AddonFilter {
             AddonKind::Debug(_) => AddonFilter::Debugs,
             AddonKind::Trace(_) => AddonFilter::Traces,
             AddonKind::Related(_) => AddonFilter::Related,
+
+            #[cfg(feature = "hint_note")]
+            AddonKind::Hint(_) => AddonFilter::Hint,
+            #[cfg(feature = "hint_note")]
+            AddonKind::Note(_) => AddonFilter::Note,
 
             #[cfg(feature = "diagnostics")]
             AddonKind::Diagnostic(_) => AddonFilter::Diagnostics,
@@ -147,6 +157,11 @@ impl TryFrom<&str> for AddonFilter {
             "traces" => AddonFilter::Traces,
             "related" => AddonFilter::Related,
             "all" => AddonFilter::AllAllowed,
+
+            #[cfg(feature = "hint_note")]
+            "hints" => AddonFilter::Hint,
+            #[cfg(feature = "hint_note")]
+            "notes" => AddonFilter::Note,
 
             #[cfg(feature = "diagnostics")]
             "diagnostics" => AddonFilter::Diagnostics,
@@ -584,6 +599,11 @@ fn get_addons(s: &mut String) -> Vec<AddonFilter> {
                         addons.push(AddonFilter::Debugs);
                         addons.push(AddonFilter::Traces);
                         addons.push(AddonFilter::Related);
+
+                        #[cfg(feature = "hint_note")]
+                        addons.push(AddonFilter::Hint);
+                        #[cfg(feature = "hint_note")]
+                        addons.push(AddonFilter::Note);
 
                         #[cfg(feature = "diagnostics")]
                         addons.push(AddonFilter::Diagnostics);

--- a/core/src/logging/intermediary_event.rs
+++ b/core/src/logging/intermediary_event.rs
@@ -71,6 +71,11 @@ impl IntermediaryLogEvent {
             AddonKind::Trace(msg) => self.entry.traces.push(msg),
             AddonKind::Related(finalized_event) => self.entry.related.push(finalized_event),
 
+            #[cfg(feature = "hint_note")]
+            AddonKind::Hint(msg) => self.entry.hints.push(msg),
+            #[cfg(feature = "hint_note")]
+            AddonKind::Note(msg) => self.entry.notes.push(msg),
+
             #[cfg(feature = "diagnostics")]
             AddonKind::Diagnostic(diag) => self.entry.diagnostics.push(diag),
 

--- a/core/src/logging/tests/filter/addons.rs
+++ b/core/src/logging/tests/filter/addons.rs
@@ -131,9 +131,33 @@ fn allow_single_id_with_all_addons() {
         "Trace addon not allowed by filter."
     );
 
+    #[cfg(feature = "hint_note")]
+    assert!(
+        filter.allow_addon(
+            log_id,
+            &this_origin!(),
+            &AddonKind::Hint("Some info".to_string())
+        ),
+        "Hint addon not allowed by filter."
+    );
+    #[cfg(feature = "hint_note")]
+    assert!(
+        filter.allow_addon(
+            log_id,
+            &this_origin!(),
+            &AddonKind::Note("Some info".to_string())
+        ),
+        "Note addon not allowed by filter."
+    );
+
     assert!(
         filter.show_origin_info(log_id, &this_origin!()),
         "Origin info not allowed by filter."
+    );
+
+    assert!(
+        filter.show_id(log_id, &this_origin!()),
+        "Event info not allowed by filter."
     );
 }
 

--- a/logid/Cargo.toml
+++ b/logid/Cargo.toml
@@ -19,6 +19,7 @@ colored = "2"
 [features]
 diagnostics = ["logid-core/diagnostics"]
 payloads = ["logid-core/payloads"]
+hint_note = ["logid-core/hint_note"]
 log_debugs = ["logid-core/log_debugs"]
 log_traces = ["logid-core/log_traces"]
 

--- a/logid/src/event_handler.rs
+++ b/logid/src/event_handler.rs
@@ -341,6 +341,15 @@ fn console_writer(log_event: Arc<Event<LogId, LogEventEntry>>, to_stderr: bool) 
 
     // Note: Addon filter is already applied on capture side, so printing what is captured is fine here
 
+    for related in entry.get_related() {
+        content.push_str(&format!(
+            "{} {}: {}\n",
+            colored_addon_start(level),
+            "Related".bold(),
+            colored_related(related)
+        ));
+    }
+
     for info in entry.get_infos() {
         content.push_str(&format!(
             "{} {}: {}\n",
@@ -383,12 +392,33 @@ fn console_writer(log_event: Arc<Event<LogId, LogEventEntry>>, to_stderr: bool) 
         ));
     }
 
-    for related in entry.get_related() {
+    #[cfg(feature = "hint_note")]
+    for hint in entry.get_hints() {
         content.push_str(&format!(
             "{} {}: {}\n",
             colored_addon_start(level),
-            "Related".bold(),
-            colored_related(related)
+            "Hint".bold(),
+            format_lines(
+                hint.lines(),
+                hint.len(),
+                get_addon_indent("Hint"),
+                get_level_color(level)
+            )
+        ));
+    }
+
+    #[cfg(feature = "hint_note")]
+    for notes in entry.get_notes() {
+        content.push_str(&format!(
+            "{} {}: {}\n",
+            colored_addon_start(level),
+            "Note".bold(),
+            format_lines(
+                notes.lines(),
+                notes.len(),
+                get_addon_indent("Note"),
+                get_level_color(level)
+            )
         ));
     }
 


### PR DESCRIPTION
closes #14 

Added support for hint/note addons behind feature flag.
Hint and note msgs may now be added to log events if the feature `hint_notes` is enabled.

![image](https://github.com/mhatzl/logid/assets/49341624/1e040d54-d38e-42d3-856a-69a78c128ad2)
