### PR TITLE
feat: remove crate_name from LogId

### DIFF
--- a/core/src/log_id.rs
+++ b/core/src/log_id.rs
@@ -2,8 +2,6 @@
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LogId {
-    pub(crate) crate_name: &'static str,
-
     pub(crate) module_path: &'static str,
 
     pub(crate) identifier: &'static str,
@@ -42,22 +40,17 @@ pub const STOP_LOGGING: LogId = crate::new_log_id!("STOP_LOGGING", LogLevel::Inf
 
 impl LogId {
     pub const fn new(
-        crate_name: &'static str,
         module_path: &'static str,
         identifier: &'static str,
         log_level: LogLevel,
     ) -> Self {
         LogId {
-            crate_name,
             module_path,
             identifier,
             log_level,
         }
     }
 
-    pub fn get_crate_name(&self) -> &'static str {
-        self.crate_name
-    }
     pub fn get_module_path(&self) -> &'static str {
         self.module_path
     }
@@ -75,8 +68,8 @@ impl std::fmt::Display for LogId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}: {}::{}::{}",
-            self.log_level, self.crate_name, self.module_path, self.identifier
+            "{}: {}::{}",
+            self.log_level, self.module_path, self.identifier
         )
     }
 }
@@ -120,12 +113,7 @@ impl std::fmt::Display for LogLevel {
 #[macro_export]
 macro_rules! new_log_id {
     ($identifier:expr, $log_level:expr) => {
-        $crate::log_id::LogId::new(
-            env!("CARGO_PKG_NAME"),
-            module_path!(),
-            $identifier,
-            $log_level,
-        )
+        $crate::log_id::LogId::new(module_path!(), $identifier, $log_level)
     };
 }
 
@@ -137,11 +125,6 @@ mod tests {
     fn create_log_id_with_macro() {
         let log_id = new_log_id!("custom_ident", LogLevel::Debug);
 
-        assert_eq!(
-            log_id.crate_name,
-            env!("CARGO_PKG_NAME"),
-            "Crate name was not set correctly using `log_id!()` macro."
-        );
         assert_eq!(
             log_id.module_path,
             module_path!(),

--- a/core/src/logging/tests/filter/addons.rs
+++ b/core/src/logging/tests/filter/addons.rs
@@ -15,8 +15,7 @@ use evident::{
 fn allow_single_id_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
     let filter = InnerLogFilter::new(&format!(
-        "on[{}::{}::{}(infos)]",
-        log_id.get_crate_name(),
+        "on[{}::{}(infos)]",
         log_id.get_module_path(),
         log_id.get_identifier()
     ));
@@ -40,8 +39,7 @@ fn allow_single_id_with_infos_addon() {
 fn allow_single_id_with_infos_and_origin_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
     let filter = InnerLogFilter::new(&format!(
-        "on[{}::{}::{}(infos & origin)]",
-        log_id.get_crate_name(),
+        "on[{}::{}(infos & origin)]",
         log_id.get_module_path(),
         log_id.get_identifier()
     ));
@@ -70,8 +68,7 @@ fn allow_single_id_with_infos_and_origin_addon() {
 fn allow_single_id_with_related_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
     let filter = InnerLogFilter::new(&format!(
-        "on[{}::{}::{}(related)]",
-        log_id.get_crate_name(),
+        "on[{}::{}(related)]",
         log_id.get_module_path(),
         log_id.get_identifier()
     ));
@@ -93,8 +90,7 @@ fn allow_single_id_with_related_addon() {
 fn allow_single_id_with_all_addons() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
     let filter = InnerLogFilter::new(&format!(
-        "on[{}::{}::{}(all)]",
-        log_id.get_crate_name(),
+        "on[{}::{}(all)]",
         log_id.get_module_path(),
         log_id.get_identifier()
     ));
@@ -164,7 +160,7 @@ fn allow_single_id_with_all_addons() {
 #[test]
 fn allow_module_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
-    let filter = InnerLogFilter::new("logid-core::logid_core(infos) = error");
+    let filter = InnerLogFilter::new("logid_core::logging(infos) = error");
 
     assert!(
         filter.allow_event(&test_event(log_id, this_origin!())),
@@ -184,7 +180,7 @@ fn allow_module_with_infos_addon() {
 #[test]
 fn allow_crate_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
-    let filter = InnerLogFilter::new("logid-core::logid_core(infos) = error");
+    let filter = InnerLogFilter::new("logid_core(infos) = error");
 
     assert!(
         filter.allow_event(&test_event(log_id, this_origin!())),

--- a/core/src/logging/tests/filter/global_ids.rs
+++ b/core/src/logging/tests/filter/global_ids.rs
@@ -9,8 +9,7 @@ use evident::{event::filter::Filter, this_origin};
 fn allow_single_id() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
     let filter = InnerLogFilter::new(&format!(
-        "on[{}::{}::{}]",
-        log_id.get_crate_name(),
+        "on[{}::{}]",
         log_id.get_module_path(),
         log_id.get_identifier()
     ));
@@ -27,11 +26,9 @@ fn allow_multiple_ids() {
     let log_id_2 = new_log_id!("log_id_2", LogLevel::Debug);
 
     let filter = InnerLogFilter::new(&format!(
-        "on[{}::{}::{} | {}::{}::{}]",
-        log_id_1.get_crate_name(),
+        "on[{}::{} | {}::{}]",
         log_id_1.get_module_path(),
         log_id_1.get_identifier(),
-        log_id_2.get_crate_name(),
         log_id_2.get_module_path(),
         log_id_2.get_identifier()
     ));
@@ -52,8 +49,7 @@ fn invalid_ids_syntax() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
 
     let filter = InnerLogFilter::new(&format!(
-        "on]{}::{}::{}[",
-        log_id.get_crate_name(),
+        "on]{}::{}[",
         log_id.get_module_path(),
         log_id.get_identifier(),
     ));

--- a/core/src/logging/tests/filter/only_module.rs
+++ b/core/src/logging/tests/filter/only_module.rs
@@ -7,7 +7,7 @@ use evident::{event::filter::Filter, this_origin};
 
 #[test]
 fn single_module() {
-    let filter = InnerLogFilter::new("logid-core::logid_core::logging = warn");
+    let filter = InnerLogFilter::new("logid_core::logging = warn");
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
@@ -23,8 +23,8 @@ fn single_module() {
 }
 
 #[test]
-fn only_crate_name() {
-    let filter = InnerLogFilter::new("logid-core = warn");
+fn only_crate_name_as_module() {
+    let filter = InnerLogFilter::new("logid_core = warn");
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
@@ -42,7 +42,7 @@ fn only_crate_name() {
 #[test]
 fn multiple_modules() {
     let filter = InnerLogFilter::new(
-        "logid-core::logid_core::logging::tests = warn, logid-core::logid_core::logging::event_entry = info",
+        "logid_core::logging::tests = warn, logid_core::logging::event_entry = info",
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
@@ -61,7 +61,7 @@ fn multiple_modules() {
 #[test]
 fn module_with_id() {
     let filter = InnerLogFilter::new(
-        "logid-core::logid_core::logging[logid-core::logid_core::logging::tests::filter::only_module::info_id] = error",
+        "logid_core::logging[logid_core::logging::tests::filter::only_module::info_id] = error",
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
@@ -80,7 +80,7 @@ fn module_with_id() {
 #[test]
 fn module_with_id_allowed_only() {
     let filter = InnerLogFilter::new(
-        "logid-core::logid_core::logging[logid-core::logid_core::logging::tests::filter::only_module::info_id]",
+        "logid_core::logging[logid_core::logging::tests::filter::only_module::info_id]",
     );
 
     let error_id = new_log_id!("error_id", LogLevel::Error);

--- a/core/src/logging/tests/filter/rule_mix.rs
+++ b/core/src/logging/tests/filter/rule_mix.rs
@@ -12,8 +12,7 @@ fn global_id_and_general_error() {
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
 
     let filter = InnerLogFilter::new(&format!(
-        "on[{}::{}::{}], error",
-        log_id.get_crate_name(),
+        "on[{}::{}], error",
         log_id.get_module_path(),
         log_id.get_identifier()
     ));

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -66,7 +66,6 @@ fn derive_log_id(input: TokenStream, log_level: LogLevel) -> TokenStream {
                         };
 
                         logid::log_id::LogId::new(
-                            env!("CARGO_PKG_NAME"),
                             module_path!(),
                             field_name,
                             #log_token,
@@ -99,7 +98,6 @@ fn from_struct_or_union(
         impl From<#ident_name> for logid::log_id::LogId {
             fn from(value: #ident_name) -> Self {
                 logid::log_id::LogId::new(
-                    env!("CARGO_PKG_NAME"),
                     module_path!(),
                     #ident_name_str,
                     #log_token,
@@ -137,8 +135,7 @@ pub fn derive_from_log_id(input: TokenStream) -> TokenStream {
             let from_log_id = quote_spanned! {span=>
                 impl From<logid::log_id::LogId> for #enum_name {
                     fn from(value: logid::log_id::LogId) -> Self {
-                        if value.get_crate_name() != env!("CARGO_PKG_NAME")
-                            || value.get_module_path() != module_path!() {
+                        if value.get_module_path() != module_path!() {
 
                             return Self::default();
                         }

--- a/logid/src/event_handler/terminal.rs
+++ b/logid/src/event_handler/terminal.rs
@@ -239,10 +239,9 @@ fn get_colored_lbot(level: LogLevel) -> String {
 }
 
 fn get_event_string(id: &LogId, entry_id: &str) -> String {
-    let crate_name = id.get_crate_name();
     let module = id.get_module_path();
     let identifier = id.get_identifier();
-    format!("id='{crate_name}::{module}::{identifier}', entry='{entry_id}'")
+    format!("id='{module}::{identifier}', entry='{entry_id}'")
 }
 
 struct ContentBuilder {

--- a/logid/tests/default_set_events.rs
+++ b/logid/tests/default_set_events.rs
@@ -98,12 +98,7 @@ fn set_event_for_err_result() {
 fn capture_logid_with_custom_identifier() {
     let msg = "Set log message";
     let identifier = "log_id";
-    let log_id = LogId::new(
-        env!("CARGO_PKG_NAME"),
-        module_path!(),
-        identifier,
-        LogLevel::Trace,
-    );
+    let log_id = LogId::new(module_path!(), identifier, LogLevel::Trace);
 
     let recv = LOGGER.subscribe(log_id).unwrap();
 

--- a/logid/tests/derive_log_id.rs
+++ b/logid/tests/derive_log_id.rs
@@ -24,11 +24,6 @@ fn enum_into_log_id() {
     let third_enum_id: LogId = LogIdEnum::Third.into();
 
     assert_eq!(
-        first_enum_id.get_crate_name(),
-        env!("CARGO_PKG_NAME"),
-        "Derive set wrong crate name."
-    );
-    assert_eq!(
         first_enum_id.get_module_path(),
         module_path!(),
         "Derive set wrong module path."


### PR DESCRIPTION
closes #21 

`LogId` hat crate name and module path as fields, but the module path starts with the transformed crate name, except in tests folder.