### PR TITLE
feat: allow formatted log msgs

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-logid = { path = "../logid", features = ["log_debugs", "log_traces", "hint_note"] }
+logid = { path = "../logid", features = ["log_debugs", "log_traces", "hint_note", "payloads", "fmt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [[bench]]
 name = "bench"

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -60,6 +60,9 @@ fn main() {
 
     log!(BenchWarn::Test, "Event logged again globally.");
 
+    // Use Display impl for "BenchWarn::Test"
+    log!(BenchWarn::Test);
+
     println!(
         "Duration: {}us\n-----------------------------\n",
         end_time
@@ -105,6 +108,12 @@ enum BenchError {
 #[derive(Debug, Clone, WarnLogId)]
 enum BenchWarn {
     Test,
+}
+
+impl std::fmt::Display for BenchWarn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BenchWarn Display impl.")
+    }
 }
 
 #[derive(Debug, Clone, InfoLogId)]

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -3,8 +3,9 @@ use logid::{
     event_handler::builder::LogEventHandlerBuilder,
     log,
     logging::{event_entry::AddonKind, LOGGER},
-    DbgLogId, ErrLogId, InfoLogId, TraceLogId, WarnLogId,
+    payload_addon, DbgLogId, ErrLogId, InfoLogId, TraceLogId, WarnLogId,
 };
+use serde::{Deserialize, Serialize};
 
 fn main() {
     let _ = logid::set_filter!("trace(all)");
@@ -40,7 +41,18 @@ fn main() {
 
     handler.start();
 
-    log!(BenchInfo::Test, "Event logged again.");
+    let payload = DummyPayload {
+        vals: vec!["First", "Second", "Third", "Fourth"]
+            .iter_mut()
+            .map(|f| f.to_string())
+            .collect(),
+    };
+
+    log!(
+        BenchInfo::Test,
+        "Event logged again.",
+        add: payload_addon!(fmt_payload, logid::serde_json::to_value(payload).unwrap())
+    );
 
     handler2.stop();
 
@@ -129,4 +141,23 @@ enum BenchDbg {
 #[derive(Debug, Clone, TraceLogId)]
 enum BenchTrace {
     Test,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DummyPayload {
+    vals: Vec<String>,
+}
+
+fn fmt_payload(data: &logid::serde_json::Value) -> String {
+    match logid::serde_json::from_value::<DummyPayload>(data.clone()) {
+        Ok(payload) => {
+            let mut s = String::new();
+            for val in payload.vals {
+                s.push_str(&val);
+                s.push('\n');
+            }
+            s
+        }
+        Err(_) => "Could not deserialize back to payload!".to_string(),
+    }
 }

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
 
     handler.start();
 
-    log!(BenchWarn::Test, "Event logged again.");
+    log!(BenchInfo::Test, "Event logged again.");
 
     handler2.stop();
 
@@ -49,16 +49,16 @@ fn main() {
         "Event logged => handler2.stop() does not affect handler."
     );
 
-    LOGGER.stop_capturing();
+    LOGGER.stop();
 
     log!(
-        BenchWarn::Test,
+        BenchError::Test,
         "Global logging stopped => Event not logged."
     );
 
-    LOGGER.start_capturing();
+    LOGGER.start();
 
-    log!(BenchWarn::Test, "Event logged again globally.");
+    log!(BenchInfo::Test, "Event logged again globally.");
 
     // Use Display impl for "BenchWarn::Test"
     log!(BenchWarn::Test);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { path = "../../evident", version = "0.11" }
+evident = { path = "../../evident", version = "0.12" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { version = "0.11" }
+evident = { path = "../../evident", version = "0.11" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evident = { path = "../../evident", version = "0.12" }
+evident = { version = "0.12" }
 lsp-types = { version = "0.94", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { version = "1.0", optional = true }
 [features]
 diagnostics = ["lsp-types"]
 payloads = ["serde_json"]
+fmt = ["serde_json"]
 hint_note = []
 log_debugs = []
 log_traces = []

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,3 +6,6 @@ pub use evident;
 
 #[cfg(feature = "diagnostics")]
 pub use lsp_types;
+
+#[cfg(any(feature = "payloads", feature = "fmt"))]
+pub use serde_json;

--- a/core/src/log_id.rs
+++ b/core/src/log_id.rs
@@ -9,7 +9,7 @@ pub struct LogId {
     pub(crate) log_level: LogLevel,
 }
 
-impl evident::publisher::Id for LogId {}
+impl evident::event::Id for LogId {}
 
 impl evident::publisher::CaptureControl for LogId {
     fn start(id: &Self) -> bool {
@@ -66,11 +66,7 @@ impl LogId {
 
 impl std::fmt::Display for LogId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}: {}::{}",
-            self.log_level, self.module_path, self.identifier
-        )
+        write!(f, "id='{}::{}'", self.module_path, self.identifier)
     }
 }
 

--- a/core/src/logging/event_entry.rs
+++ b/core/src/logging/event_entry.rs
@@ -3,6 +3,8 @@ use evident::event::finalized::FinalizedEvent;
 use crate::evident::event::origin::Origin;
 use crate::log_id::{LogId, LogLevel};
 
+use super::msg::LogMsg;
+
 #[derive(Default, Debug, Clone)]
 pub struct LogEventEntry {
     /// The event id of this entry
@@ -10,7 +12,7 @@ pub struct LogEventEntry {
     /// The unique id of this entry
     pub(crate) entry_id: crate::evident::uuid::Uuid,
     /// The main message set when creating the log-id entry
-    pub(crate) msg: String,
+    pub(crate) msg: Option<LogMsg>,
     /// List of additional informations for this log-id entry
     pub(crate) infos: Vec<String>,
     /// List of additional debug informations for this log-id entry
@@ -38,12 +40,12 @@ pub struct LogEventEntry {
     pub(crate) payloads: Vec<serde_json::value::Value>,
 }
 
-impl crate::evident::event::entry::EventEntry<LogId> for LogEventEntry {
-    fn new(event_id: LogId, msg: &str, origin: Origin) -> Self {
+impl crate::evident::event::entry::EventEntry<LogId, LogMsg> for LogEventEntry {
+    fn new(event_id: LogId, msg: Option<impl Into<LogMsg>>, origin: Origin) -> Self {
         LogEventEntry {
             event_id,
             entry_id: crate::evident::uuid::Uuid::new_v4(),
-            msg: msg.to_string(),
+            msg: msg.map(|m| m.into()),
             infos: Vec::new(),
             debugs: Vec::new(),
             traces: Vec::new(),
@@ -75,8 +77,8 @@ impl crate::evident::event::entry::EventEntry<LogId> for LogEventEntry {
         self.entry_id
     }
 
-    fn get_msg(&self) -> &str {
-        &self.msg
+    fn get_msg(&self) -> Option<&LogMsg> {
+        self.msg.as_ref()
     }
 
     fn get_origin(&self) -> &crate::evident::event::origin::Origin {
@@ -88,10 +90,6 @@ impl LogEventEntry {
     /// Get the level of the log-id of this entry
     pub fn get_level(&self) -> LogLevel {
         self.event_id.log_level
-    }
-    /// Get the main message set when creating the log-id entry
-    pub fn get_msg(&self) -> &String {
-        &self.msg
     }
 
     /// Get the code position where the log-id entry was created

--- a/core/src/logging/event_entry.rs
+++ b/core/src/logging/event_entry.rs
@@ -5,6 +5,9 @@ use crate::log_id::{LogId, LogLevel};
 
 use super::msg::LogMsg;
 
+#[cfg(feature = "fmt")]
+use super::msg::FmtMsg;
+
 #[derive(Default, Debug, Clone)]
 pub struct LogEventEntry {
     /// The event id of this entry
@@ -15,10 +18,19 @@ pub struct LogEventEntry {
     pub(crate) msg: Option<LogMsg>,
     /// List of additional informations for this log-id entry
     pub(crate) infos: Vec<String>,
+    /// List of additional formatted information for this log-id entry
+    #[cfg(feature = "fmt")]
+    pub(crate) fmt_infos: Vec<FmtMsg>,
     /// List of additional debug informations for this log-id entry
     pub(crate) debugs: Vec<String>,
+    /// List of additional formatted debug information for this log-id entry
+    #[cfg(feature = "fmt")]
+    pub(crate) fmt_debugs: Vec<FmtMsg>,
     /// List of additional trace information for this log-id entry
     pub(crate) traces: Vec<String>,
+    /// List of additional formatted trace information for this log-id entry
+    #[cfg(feature = "fmt")]
+    pub(crate) fmt_traces: Vec<FmtMsg>,
     /// List of related log-id event entries
     pub(crate) related: Vec<FinalizedEvent<LogId>>,
     /// Code position where the log-id entry was created
@@ -27,17 +39,29 @@ pub struct LogEventEntry {
     /// List of hints for this log-id entry
     #[cfg(feature = "hint_note")]
     pub(crate) hints: Vec<String>,
+    /// List of formatted hints for this log-id entry
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    pub(crate) fmt_hints: Vec<FmtMsg>,
     /// List of notes for this log-id entry
     #[cfg(feature = "hint_note")]
     pub(crate) notes: Vec<String>,
+    /// List of formatted notes for this log-id entry
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    pub(crate) fmt_notes: Vec<FmtMsg>,
 
     /// List of diagnostics for this log-id entry
     #[cfg(feature = "diagnostics")]
     pub(crate) diagnostics: Vec<crate::lsp_types::Diagnostic>,
+    /// List of formatted diagnostics for this log-id entry
+    #[cfg(all(feature = "diagnostics", feature = "fmt"))]
+    pub(crate) fmt_diagnostics: Vec<FmtDiagnostics>,
 
     /// List of payloads for this log-id entry
     #[cfg(feature = "payloads")]
-    pub(crate) payloads: Vec<serde_json::value::Value>,
+    pub(crate) payloads: Vec<crate::serde_json::value::Value>,
+    /// List of formatted payloads for this log-id entry
+    #[cfg(all(feature = "payloads", feature = "fmt"))]
+    pub(crate) fmt_payloads: Vec<FmtMsg>,
 }
 
 impl crate::evident::event::entry::EventEntry<LogId, LogMsg> for LogEventEntry {
@@ -52,16 +76,31 @@ impl crate::evident::event::entry::EventEntry<LogId, LogMsg> for LogEventEntry {
             related: Vec::new(),
             origin,
 
+            #[cfg(feature = "fmt")]
+            fmt_infos: Vec::new(),
+            #[cfg(feature = "fmt")]
+            fmt_debugs: Vec::new(),
+            #[cfg(feature = "fmt")]
+            fmt_traces: Vec::new(),
+
             #[cfg(feature = "hint_note")]
             hints: Vec::new(),
+            #[cfg(all(feature = "hint_note", feature = "fmt"))]
+            fmt_hints: Vec::new(),
             #[cfg(feature = "hint_note")]
             notes: Vec::new(),
+            #[cfg(all(feature = "hint_note", feature = "fmt"))]
+            fmt_notes: Vec::new(),
 
             #[cfg(feature = "diagnostics")]
             diagnostics: Vec::new(),
+            #[cfg(all(feature = "diagnostics", feature = "fmt"))]
+            fmt_diagnostics: Vec::new(),
 
             #[cfg(feature = "payloads")]
             payloads: Vec::new(),
+            #[cfg(all(feature = "payloads", feature = "fmt"))]
+            fmt_payloads: Vec::new(),
         }
     }
 
@@ -101,13 +140,28 @@ impl LogEventEntry {
     pub fn get_infos(&self) -> &Vec<String> {
         &self.infos
     }
+    /// Get the list of additional formatted informations for this log-id entry
+    #[cfg(feature = "fmt")]
+    pub fn get_fmt_infos(&self) -> &Vec<FmtMsg> {
+        &self.fmt_infos
+    }
     /// Get the list of additional debug informations for this log-id entry
     pub fn get_debugs(&self) -> &Vec<String> {
         &self.debugs
     }
+    /// Get the list of additional formatted debug informations for this log-id entry
+    #[cfg(feature = "fmt")]
+    pub fn get_fmt_debugs(&self) -> &Vec<FmtMsg> {
+        &self.fmt_debugs
+    }
     /// Get the list of additional trace information for this log-id entry
     pub fn get_traces(&self) -> &Vec<String> {
         &self.traces
+    }
+    /// Get the list of additional formatted trace informations for this log-id entry
+    #[cfg(feature = "fmt")]
+    pub fn get_fmt_traces(&self) -> &Vec<FmtMsg> {
+        &self.fmt_traces
     }
     /// Get the list of related log-id event entries
     pub fn get_related(&self) -> &Vec<FinalizedEvent<LogId>> {
@@ -118,20 +172,36 @@ impl LogEventEntry {
     pub fn get_hints(&self) -> &Vec<String> {
         &self.hints
     }
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    pub fn get_fmt_hints(&self) -> &Vec<FmtMsg> {
+        &self.fmt_hints
+    }
 
     #[cfg(feature = "hint_note")]
     pub fn get_notes(&self) -> &Vec<String> {
         &self.notes
+    }
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    pub fn get_fmt_notes(&self) -> &Vec<FmtMsg> {
+        &self.fmt_notes
     }
 
     #[cfg(feature = "diagnostics")]
     pub fn get_diagnostics(&self) -> &Vec<crate::lsp_types::Diagnostic> {
         &self.diagnostics
     }
+    #[cfg(all(feature = "diagnostics", feature = "fmt"))]
+    pub fn get_fmt_diagnostics(&self) -> &Vec<FmtDiagnostics> {
+        &self.fmt_diagnostics
+    }
 
     #[cfg(feature = "payloads")]
-    pub fn get_payloads(&self) -> &Vec<serde_json::value::Value> {
+    pub fn get_payloads(&self) -> &Vec<crate::serde_json::value::Value> {
         &self.payloads
+    }
+    #[cfg(all(feature = "payloads", feature = "fmt"))]
+    pub fn get_fmt_payloads(&self) -> &Vec<FmtMsg> {
+        &self.fmt_payloads
     }
 }
 
@@ -143,14 +213,162 @@ pub enum AddonKind {
     Trace(String),
     Related(FinalizedEvent<LogId>),
 
+    #[cfg(feature = "fmt")]
+    FmtInfo(FmtMsg),
+    #[cfg(feature = "fmt")]
+    FmtDebug(FmtMsg),
+    #[cfg(feature = "fmt")]
+    FmtTrace(FmtMsg),
+
     #[cfg(feature = "hint_note")]
     Hint(String),
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    FmtHint(FmtMsg),
     #[cfg(feature = "hint_note")]
     Note(String),
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    FmtNote(FmtMsg),
 
     #[cfg(feature = "diagnostics")]
     Diagnostic(crate::lsp_types::Diagnostic),
+    #[cfg(all(feature = "diagnostics", feature = "fmt"))]
+    FmtDiagnostic(FmtDiagnostics),
 
     #[cfg(feature = "payloads")]
-    Payload(serde_json::value::Value),
+    Payload(crate::serde_json::value::Value),
+    #[cfg(all(feature = "payloads", feature = "fmt"))]
+    FmtPayload(FmtMsg),
+}
+
+#[cfg(all(feature = "diagnostics", feature = "fmt"))]
+#[derive(Clone)]
+pub struct FmtDiagnostics {
+    func: for<'a> fn(&'a crate::lsp_types::Diagnostic) -> String,
+    data: crate::lsp_types::Diagnostic,
+}
+
+#[cfg(all(feature = "diagnostics", feature = "fmt"))]
+impl FmtDiagnostics {
+    pub fn new(
+        func: for<'a> fn(&'a crate::lsp_types::Diagnostic) -> String,
+        data: crate::lsp_types::Diagnostic,
+    ) -> Self {
+        FmtDiagnostics { func, data }
+    }
+
+    pub fn get_data(&self) -> &crate::lsp_types::Diagnostic {
+        &self.data
+    }
+}
+
+#[cfg(all(feature = "diagnostics", feature = "fmt"))]
+impl std::fmt::Debug for FmtDiagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", (self.func)(&self.data))
+    }
+}
+
+#[cfg(all(feature = "diagnostics", feature = "fmt"))]
+impl std::fmt::Display for FmtDiagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", (self.func)(&self.data))
+    }
+}
+
+#[cfg(all(feature = "diagnostics", feature = "fmt"))]
+impl PartialEq<FmtDiagnostics> for FmtDiagnostics {
+    fn eq(&self, other: &FmtDiagnostics) -> bool {
+        (self.func)(&self.data) == (other.func)(&other.data)
+    }
+}
+
+#[cfg(all(feature = "diagnostics", feature = "fmt"))]
+impl Eq for FmtDiagnostics {}
+
+#[macro_export]
+macro_rules! info_addon {
+    ($msg:expr) => {
+        $crate::logging::event_entry::AddonKind::Info($msg)
+    };
+    ($fmt_fn:expr, $fmt_data:expr) => {
+        $crate::logging::event_entry::AddonKind::FmtInfo($crate::logging::msg::FmtMsg::new(
+            $fmt_fn, $fmt_data,
+        ))
+    };
+}
+
+#[macro_export]
+macro_rules! debug_addon {
+    ($msg:expr) => {
+        $crate::logging::event_entry::AddonKind::Debug($msg)
+    };
+    ($fmt_fn:expr, $fmt_data:expr) => {
+        $crate::logging::event_entry::AddonKind::FmtDebug($crate::logging::msg::FmtMsg::new(
+            $fmt_fn, $fmt_data,
+        ))
+    };
+}
+
+#[macro_export]
+macro_rules! trace_addon {
+    ($msg:expr) => {
+        $crate::logging::event_entry::AddonKind::Trace($msg)
+    };
+    ($fmt_fn:expr, $fmt_data:expr) => {
+        $crate::logging::event_entry::AddonKind::FmtTrace($crate::logging::msg::FmtMsg::new(
+            $fmt_fn, $fmt_data,
+        ))
+    };
+}
+
+#[cfg(feature = "hint_note")]
+#[macro_export]
+macro_rules! hint_addon {
+    ($msg:expr) => {
+        $crate::logging::event_entry::AddonKind::Hint($msg)
+    };
+    ($fmt_fn:expr, $fmt_data:expr) => {
+        $crate::logging::event_entry::AddonKind::FmtHint($crate::logging::msg::FmtMsg::new(
+            $fmt_fn, $fmt_data,
+        ))
+    };
+}
+
+#[cfg(feature = "hint_note")]
+#[macro_export]
+macro_rules! note_addon {
+    ($msg:expr) => {
+        $crate::logging::event_entry::AddonKind::Note($msg)
+    };
+    ($fmt_fn:expr, $fmt_data:expr) => {
+        $crate::logging::event_entry::AddonKind::FmtNote($crate::logging::msg::FmtMsg::new(
+            $fmt_fn, $fmt_data,
+        ))
+    };
+}
+
+#[cfg(feature = "diagnostics")]
+#[macro_export]
+macro_rules! diagnostic_addon {
+    ($msg:expr) => {
+        $crate::logging::event_entry::AddonKind::Diagnostic($msg)
+    };
+    ($fmt_fn:expr, $fmt_data:expr) => {
+        $crate::logging::event_entry::AddonKind::FmtDiagnostic(
+            $crate::logging::event_entry::FmtDiagnostics::new($fmt_fn, $fmt_data),
+        )
+    };
+}
+
+#[cfg(feature = "payloads")]
+#[macro_export]
+macro_rules! payload_addon {
+    ($msg:expr) => {
+        $crate::logging::event_entry::AddonKind::Payload($msg)
+    };
+    ($fmt_fn:expr, $fmt_data:expr) => {
+        $crate::logging::event_entry::AddonKind::FmtPayload($crate::logging::msg::FmtMsg::new(
+            $fmt_fn, $fmt_data,
+        ))
+    };
 }

--- a/core/src/logging/event_entry.rs
+++ b/core/src/logging/event_entry.rs
@@ -79,10 +79,6 @@ impl crate::evident::event::entry::EventEntry<LogId> for LogEventEntry {
         &self.msg
     }
 
-    fn get_crate_name(&self) -> &'static str {
-        self.origin.crate_name
-    }
-
     fn get_origin(&self) -> &crate::evident::event::origin::Origin {
         &self.origin
     }

--- a/core/src/logging/filter.rs
+++ b/core/src/logging/filter.rs
@@ -131,16 +131,31 @@ impl From<&AddonKind> for AddonFilter {
             AddonKind::Trace(_) => AddonFilter::Traces,
             AddonKind::Related(_) => AddonFilter::Related,
 
+            #[cfg(feature = "fmt")]
+            AddonKind::FmtInfo(_) => AddonFilter::Infos,
+            #[cfg(feature = "fmt")]
+            AddonKind::FmtDebug(_) => AddonFilter::Debugs,
+            #[cfg(feature = "fmt")]
+            AddonKind::FmtTrace(_) => AddonFilter::Traces,
+
             #[cfg(feature = "hint_note")]
             AddonKind::Hint(_) => AddonFilter::Hint,
+            #[cfg(all(feature = "hint_note", feature = "fmt"))]
+            AddonKind::FmtHint(_) => AddonFilter::Hint,
             #[cfg(feature = "hint_note")]
             AddonKind::Note(_) => AddonFilter::Note,
+            #[cfg(all(feature = "hint_note", feature = "fmt"))]
+            AddonKind::FmtNote(_) => AddonFilter::Note,
 
             #[cfg(feature = "diagnostics")]
             AddonKind::Diagnostic(_) => AddonFilter::Diagnostics,
+            #[cfg(all(feature = "diagnostics", feature = "fmt"))]
+            AddonKind::FmtDiagnostic(_) => AddonFilter::Diagnostics,
 
             #[cfg(feature = "payloads")]
             AddonKind::Payload(_) => AddonFilter::Payloads,
+            #[cfg(all(feature = "payloads", feature = "fmt"))]
+            AddonKind::FmtPayload(_) => AddonFilter::Payloads,
         }
     }
 }

--- a/core/src/logging/filter.rs
+++ b/core/src/logging/filter.rs
@@ -4,7 +4,7 @@ use evident::event::origin::Origin;
 
 use crate::log_id::{LogId, LogLevel};
 
-use super::event_entry::AddonKind;
+use super::{event_entry::AddonKind, msg::LogMsg};
 
 #[derive(Default, Debug)]
 pub struct LogFilter {
@@ -87,8 +87,8 @@ fn filter_config() -> String {
     }
 }
 
-impl evident::event::filter::Filter<LogId> for LogFilter {
-    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<LogId>) -> bool {
+impl evident::event::filter::Filter<LogId, LogMsg> for LogFilter {
+    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<LogId, LogMsg>) -> bool {
         if !allow_level(entry.get_event_id().log_level) {
             return false;
         }
@@ -429,8 +429,8 @@ impl InnerLogFilter {
     }
 }
 
-impl evident::event::filter::Filter<LogId> for InnerLogFilter {
-    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<LogId>) -> bool {
+impl evident::event::filter::Filter<LogId, LogMsg> for InnerLogFilter {
+    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<LogId, LogMsg>) -> bool {
         // Note: event handler creates unique LogIds per handler => filter on origin
         if entry
             .get_origin()

--- a/core/src/logging/filter.rs
+++ b/core/src/logging/filter.rs
@@ -4,7 +4,7 @@ use evident::event::origin::Origin;
 
 use crate::log_id::{LogId, LogLevel};
 
-use super::event_entry::{AddonKind, LogEventEntry};
+use super::event_entry::AddonKind;
 
 #[derive(Default, Debug)]
 pub struct LogFilter {
@@ -87,14 +87,14 @@ fn filter_config() -> String {
     }
 }
 
-impl evident::event::filter::Filter<LogId, LogEventEntry> for LogFilter {
-    fn allow_event(&self, event: &evident::event::Event<LogId, LogEventEntry>) -> bool {
-        if !allow_level(event.get_event_id().log_level) {
+impl evident::event::filter::Filter<LogId> for LogFilter {
+    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<LogId>) -> bool {
+        if !allow_level(entry.get_event_id().log_level) {
             return false;
         }
 
         match self.filter.read() {
-            Ok(locked_filter) => locked_filter.allow_event(event),
+            Ok(locked_filter) => locked_filter.allow_entry(entry),
             Err(_) => false,
         }
     }
@@ -429,11 +429,10 @@ impl InnerLogFilter {
     }
 }
 
-impl evident::event::filter::Filter<LogId, LogEventEntry> for InnerLogFilter {
-    fn allow_event(&self, event: &evident::event::Event<LogId, LogEventEntry>) -> bool {
+impl evident::event::filter::Filter<LogId> for InnerLogFilter {
+    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<LogId>) -> bool {
         // Note: event handler creates unique LogIds per handler => filter on origin
-        if event
-            .get_entry()
+        if entry
             .get_origin()
             .module_path
             .starts_with("logid::event_handler")
@@ -442,15 +441,15 @@ impl evident::event::filter::Filter<LogId, LogEventEntry> for InnerLogFilter {
         }
 
         // Note: `Error` starts at `0`
-        if !self.no_general_logging && self.general_level >= event.get_event_id().log_level {
+        if !self.no_general_logging && self.general_level >= entry.get_event_id().log_level {
             return true;
         }
 
-        id_allowed(&self.allowed_global_ids, *event.get_event_id())
+        id_allowed(&self.allowed_global_ids, *entry.get_event_id())
             || id_allowed_in_origin(
                 &self.allowed_modules,
-                *event.get_event_id(),
-                &event.get_entry().origin,
+                *entry.get_event_id(),
+                entry.get_origin(),
             )
     }
 }

--- a/core/src/logging/intermediary_event.rs
+++ b/core/src/logging/intermediary_event.rs
@@ -67,16 +67,31 @@ impl IntermediaryLogEvent {
             AddonKind::Trace(msg) => self.entry.traces.push(msg),
             AddonKind::Related(finalized_event) => self.entry.related.push(finalized_event),
 
+            #[cfg(feature = "fmt")]
+            AddonKind::FmtInfo(fmt_msg) => self.entry.fmt_infos.push(fmt_msg),
+            #[cfg(feature = "fmt")]
+            AddonKind::FmtDebug(fmt_msg) => self.entry.fmt_debugs.push(fmt_msg),
+            #[cfg(feature = "fmt")]
+            AddonKind::FmtTrace(fmt_msg) => self.entry.fmt_traces.push(fmt_msg),
+
             #[cfg(feature = "hint_note")]
             AddonKind::Hint(msg) => self.entry.hints.push(msg),
+            #[cfg(all(feature = "hint_note", feature = "fmt"))]
+            AddonKind::FmtHint(fmt_msg) => self.entry.fmt_hints.push(fmt_msg),
             #[cfg(feature = "hint_note")]
             AddonKind::Note(msg) => self.entry.notes.push(msg),
+            #[cfg(all(feature = "hint_note", feature = "fmt"))]
+            AddonKind::FmtNote(fmt_msg) => self.entry.fmt_notes.push(fmt_msg),
 
             #[cfg(feature = "diagnostics")]
             AddonKind::Diagnostic(diag) => self.entry.diagnostics.push(diag),
+            #[cfg(all(feature = "diagnostics", feature = "fmt"))]
+            AddonKind::FmtDiagnostic(fmt_diag) => self.entry.fmt_diagnostics.push(fmt_diag),
 
             #[cfg(feature = "payloads")]
             AddonKind::Payload(payload) => self.entry.payloads.push(payload),
+            #[cfg(all(feature = "payloads", feature = "fmt"))]
+            AddonKind::FmtPayload(fmt_payload) => self.entry.fmt_payloads.push(fmt_payload),
         }
         self
     }

--- a/core/src/logging/intermediary_event.rs
+++ b/core/src/logging/intermediary_event.rs
@@ -48,11 +48,6 @@ impl IntermediaryLogEvent {
         self.entry.event_id
     }
 
-    /// Returns the name of the associated crate of this log-id event
-    pub fn get_crate_name(&self) -> &'static str {
-        self.entry.origin.crate_name
-    }
-
     /// Returns the [`Entry`] of this log-id event
     pub fn get_entry(&self) -> &LogEventEntry {
         &self.entry

--- a/core/src/logging/intermediary_event.rs
+++ b/core/src/logging/intermediary_event.rs
@@ -4,6 +4,7 @@ use crate::log_id::LogId;
 
 use super::{
     event_entry::{AddonKind, LogEventEntry},
+    msg::LogMsg,
     LOGGER,
 };
 
@@ -14,10 +15,10 @@ pub struct IntermediaryLogEvent {
     pub(crate) entry: LogEventEntry,
 }
 
-impl evident::event::intermediary::IntermediaryEvent<LogId, LogEventEntry>
+impl evident::event::intermediary::IntermediaryEvent<LogId, LogMsg, LogEventEntry>
     for IntermediaryLogEvent
 {
-    fn new(event_id: LogId, msg: &str, origin: Origin) -> Self {
+    fn new(event_id: LogId, msg: Option<impl Into<LogMsg>>, origin: Origin) -> Self {
         IntermediaryLogEvent {
             entry: LogEventEntry::new(event_id, msg, origin),
         }

--- a/core/src/logging/mod.rs
+++ b/core/src/logging/mod.rs
@@ -2,11 +2,13 @@ use crate::log_id::LogId;
 
 use self::{
     event_entry::LogEventEntry, filter::LogFilter, intermediary_event::IntermediaryLogEvent,
+    msg::LogMsg,
 };
 
 pub mod event_entry;
 pub mod filter;
 pub mod intermediary_event;
+pub mod msg;
 
 #[cfg(test)]
 pub mod tests;
@@ -14,6 +16,7 @@ pub mod tests;
 evident::create_static_publisher!(
     pub LOGGER,
     id_type = LogId,
+    msg_type = LogMsg,
     entry_type = LogEventEntry,
     interm_event_type = IntermediaryLogEvent,
     filter_type = LogFilter,

--- a/core/src/logging/msg.rs
+++ b/core/src/logging/msg.rs
@@ -1,0 +1,46 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogMsg {
+    msg: String,
+}
+
+pub const NO_MSG: Option<LogMsg> = None;
+
+impl evident::event::Msg for LogMsg {}
+
+impl std::fmt::Display for LogMsg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl From<String> for LogMsg {
+    fn from(value: String) -> Self {
+        LogMsg { msg: value }
+    }
+}
+
+impl From<&str> for LogMsg {
+    fn from(value: &str) -> Self {
+        LogMsg {
+            msg: value.to_string(),
+        }
+    }
+}
+
+impl From<LogMsg> for String {
+    fn from(value: LogMsg) -> Self {
+        value.msg
+    }
+}
+
+impl PartialEq<String> for LogMsg {
+    fn eq(&self, other: &String) -> bool {
+        self.msg.eq(other)
+    }
+}
+
+impl PartialEq<str> for LogMsg {
+    fn eq(&self, other: &str) -> bool {
+        self.msg.eq(other)
+    }
+}

--- a/core/src/logging/tests/filter/addons.rs
+++ b/core/src/logging/tests/filter/addons.rs
@@ -2,7 +2,7 @@ use crate::{
     log_id::LogLevel,
     logging::{
         event_entry::AddonKind, filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent,
-        tests::filter::test_event,
+        tests::filter::test_entry,
     },
     new_log_id,
 };
@@ -21,7 +21,7 @@ fn allow_single_id_with_infos_addon() {
     ));
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
@@ -45,7 +45,7 @@ fn allow_single_id_with_infos_and_origin_addon() {
     ));
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
@@ -74,7 +74,7 @@ fn allow_single_id_with_related_addon() {
     ));
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
@@ -96,7 +96,7 @@ fn allow_single_id_with_all_addons() {
     ));
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
@@ -163,7 +163,7 @@ fn allow_module_with_infos_addon() {
     let filter = InnerLogFilter::new("logid_core::logging(infos) = error");
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Error level not allowed by filter."
     );
 
@@ -183,7 +183,7 @@ fn allow_crate_with_infos_addon() {
     let filter = InnerLogFilter::new("logid_core(infos) = error");
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Error level not allowed by filter."
     );
 
@@ -203,7 +203,7 @@ fn allow_general_level_with_infos_addon() {
     let filter = InnerLogFilter::new("error(infos)");
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Error level not allowed by filter."
     );
 

--- a/core/src/logging/tests/filter/addons.rs
+++ b/core/src/logging/tests/filter/addons.rs
@@ -2,7 +2,7 @@ use crate::{
     log_id::LogLevel,
     logging::{
         event_entry::AddonKind, filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent,
-        tests::filter::test_entry,
+        msg::NO_MSG, tests::filter::test_entry,
     },
     new_log_id,
 };
@@ -78,7 +78,7 @@ fn allow_single_id_with_related_addon() {
         "Explicitly allowed LogId not allowed by filter."
     );
 
-    let log_event = IntermediaryLogEvent::new(log_id, "", this_origin!());
+    let log_event = IntermediaryLogEvent::new(log_id, NO_MSG, this_origin!());
     let finalized = log_event.finalize();
     assert!(
         filter.allow_addon(log_id, &this_origin!(), &AddonKind::Related(finalized)),

--- a/core/src/logging/tests/filter/global_ids.rs
+++ b/core/src/logging/tests/filter/global_ids.rs
@@ -1,6 +1,6 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_event},
+    logging::{filter::InnerLogFilter, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
@@ -15,7 +15,7 @@ fn allow_single_id() {
     ));
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 }
@@ -34,12 +34,12 @@ fn allow_multiple_ids() {
     ));
 
     assert!(
-        filter.allow_event(&test_event(log_id_1, this_origin!())),
+        filter.allow_entry(&test_entry(log_id_1, this_origin!())),
         "Explicitly allowed first LogId not allowed by filter."
     );
 
     assert!(
-        filter.allow_event(&test_event(log_id_2, this_origin!())),
+        filter.allow_entry(&test_entry(log_id_2, this_origin!())),
         "Explicitly allowed second LogId not allowed by filter."
     );
 }
@@ -55,7 +55,7 @@ fn invalid_ids_syntax() {
     ));
 
     assert!(
-        !filter.allow_event(&test_event(log_id, this_origin!())),
+        !filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Invalid filter syntax allowed LogId by filter."
     );
 }

--- a/core/src/logging/tests/filter/mod.rs
+++ b/core/src/logging/tests/filter/mod.rs
@@ -1,6 +1,9 @@
 use evident::event::{entry::EventEntry, origin::Origin};
 
-use crate::{log_id::LogId, logging::event_entry::LogEventEntry};
+use crate::{
+    log_id::LogId,
+    logging::{event_entry::LogEventEntry, msg::NO_MSG},
+};
 
 pub mod addons;
 pub mod global_ids;
@@ -9,5 +12,5 @@ pub mod only_module;
 pub mod rule_mix;
 
 fn test_entry(log_id: LogId, origin: Origin) -> LogEventEntry {
-    LogEventEntry::new(log_id, "", origin)
+    LogEventEntry::new(log_id, NO_MSG, origin)
 }

--- a/core/src/logging/tests/filter/mod.rs
+++ b/core/src/logging/tests/filter/mod.rs
@@ -1,9 +1,6 @@
-use evident::event::{intermediary::IntermediaryEvent, origin::Origin, Event};
+use evident::event::{entry::EventEntry, origin::Origin};
 
-use crate::{
-    log_id::LogId,
-    logging::{event_entry::LogEventEntry, intermediary_event::IntermediaryLogEvent},
-};
+use crate::{log_id::LogId, logging::event_entry::LogEventEntry};
 
 pub mod addons;
 pub mod global_ids;
@@ -11,6 +8,6 @@ pub mod only_general;
 pub mod only_module;
 pub mod rule_mix;
 
-fn test_event(log_id: LogId, origin: Origin) -> Event<LogId, LogEventEntry> {
-    Event::new(IntermediaryLogEvent::new(log_id, "", origin).take_entry())
+fn test_entry(log_id: LogId, origin: Origin) -> LogEventEntry {
+    LogEventEntry::new(log_id, "", origin)
 }

--- a/core/src/logging/tests/filter/only_general.rs
+++ b/core/src/logging/tests/filter/only_general.rs
@@ -1,6 +1,6 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_event},
+    logging::{filter::InnerLogFilter, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
@@ -12,7 +12,7 @@ fn logging_turned_off() {
     let error_id = new_log_id!("err_id", LogLevel::Error);
 
     assert!(
-        !filter.allow_event(&test_event(error_id, this_origin!())),
+        !filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId allowed by filter."
     );
 }
@@ -24,7 +24,7 @@ fn empty_filter_means_logging_turned_off() {
     let error_id = new_log_id!("err_id", LogLevel::Error);
 
     assert!(
-        !filter.allow_event(&test_event(error_id, this_origin!())),
+        !filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId allowed by filter."
     );
 }
@@ -35,13 +35,13 @@ fn only_allow_error() {
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
-        filter.allow_event(&test_event(error_id, this_origin!())),
+        filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        !filter.allow_event(&test_event(warn_id, this_origin!())),
+        !filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId allowed by filter."
     );
 }
@@ -52,19 +52,19 @@ fn allow_error_and_warning() {
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
-        filter.allow_event(&test_event(error_id, this_origin!())),
+        filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        !filter.allow_event(&test_event(info_id, this_origin!())),
+        !filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -75,25 +75,25 @@ fn allow_error_warning_and_info() {
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
-        filter.allow_event(&test_event(error_id, this_origin!())),
+        filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        filter.allow_event(&test_event(info_id, this_origin!())),
+        filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
     assert!(
-        !filter.allow_event(&test_event(debug_id, this_origin!())),
+        !filter.allow_entry(&test_entry(debug_id, this_origin!())),
         "Debug level LogId allowed by filter."
     );
 }
@@ -104,31 +104,31 @@ fn allow_error_warning_info_and_debug() {
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
-        filter.allow_event(&test_event(error_id, this_origin!())),
+        filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        filter.allow_event(&test_event(info_id, this_origin!())),
+        filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
     assert!(
-        filter.allow_event(&test_event(debug_id, this_origin!())),
+        filter.allow_entry(&test_entry(debug_id, this_origin!())),
         "Debug level LogId not allowed by filter."
     );
 
     let trace_id = new_log_id!("trace_id", LogLevel::Trace);
     assert!(
-        !filter.allow_event(&test_event(trace_id, this_origin!())),
+        !filter.allow_entry(&test_entry(trace_id, this_origin!())),
         "Trace level LogId allowed by filter."
     );
 }
@@ -139,31 +139,31 @@ fn allow_error_warning_info_debug_and_trace() {
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
-        filter.allow_event(&test_event(error_id, this_origin!())),
+        filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        filter.allow_event(&test_event(info_id, this_origin!())),
+        filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
     assert!(
-        filter.allow_event(&test_event(debug_id, this_origin!())),
+        filter.allow_entry(&test_entry(debug_id, this_origin!())),
         "Debug level LogId not allowed by filter."
     );
 
     let trace_id = new_log_id!("trace_id", LogLevel::Trace);
     assert!(
-        filter.allow_event(&test_event(trace_id, this_origin!())),
+        filter.allow_entry(&test_entry(trace_id, this_origin!())),
         "Trace level LogId not allowed by filter."
     );
 }
@@ -174,31 +174,31 @@ fn logging_on_equal_to_trace() {
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
-        filter.allow_event(&test_event(error_id, this_origin!())),
+        filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId not allowed by filter."
     );
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        filter.allow_event(&test_event(info_id, this_origin!())),
+        filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId not allowed by filter."
     );
 
     let debug_id = new_log_id!("debug_id", LogLevel::Debug);
     assert!(
-        filter.allow_event(&test_event(debug_id, this_origin!())),
+        filter.allow_entry(&test_entry(debug_id, this_origin!())),
         "Debug level LogId not allowed by filter."
     );
 
     let trace_id = new_log_id!("trace_id", LogLevel::Trace);
     assert!(
-        filter.allow_event(&test_event(trace_id, this_origin!())),
+        filter.allow_entry(&test_entry(trace_id, this_origin!())),
         "Trace level LogId not allowed by filter."
     );
 }

--- a/core/src/logging/tests/filter/only_module.rs
+++ b/core/src/logging/tests/filter/only_module.rs
@@ -1,6 +1,6 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_event},
+    logging::{filter::InnerLogFilter, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
@@ -11,13 +11,13 @@ fn single_module() {
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        !filter.allow_event(&test_event(info_id, this_origin!())),
+        !filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -28,13 +28,13 @@ fn only_crate_name_as_module() {
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        !filter.allow_event(&test_event(info_id, this_origin!())),
+        !filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -47,13 +47,13 @@ fn multiple_modules() {
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        filter.allow_event(&test_event(warn_id, this_origin!())),
+        filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId not allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        !filter.allow_event(&test_event(info_id, this_origin!())),
+        !filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Info level LogId allowed by filter."
     );
 }
@@ -66,13 +66,13 @@ fn module_with_id() {
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
-        !filter.allow_event(&test_event(warn_id, this_origin!())),
+        !filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level LogId allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        filter.allow_event(&test_event(info_id, this_origin!())),
+        filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 }
@@ -85,13 +85,13 @@ fn module_with_id_allowed_only() {
 
     let error_id = new_log_id!("error_id", LogLevel::Error);
     assert!(
-        !filter.allow_event(&test_event(error_id, this_origin!())),
+        !filter.allow_entry(&test_entry(error_id, this_origin!())),
         "Error level LogId allowed by filter."
     );
 
     let info_id = new_log_id!("info_id", LogLevel::Info);
     assert!(
-        filter.allow_event(&test_event(info_id, this_origin!())),
+        filter.allow_entry(&test_entry(info_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 }

--- a/core/src/logging/tests/filter/rule_mix.rs
+++ b/core/src/logging/tests/filter/rule_mix.rs
@@ -1,6 +1,6 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_event},
+    logging::{filter::InnerLogFilter, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
@@ -18,17 +18,17 @@ fn global_id_and_general_error() {
     ));
 
     assert!(
-        filter.allow_event(&test_event(log_id, this_origin!())),
+        filter.allow_entry(&test_entry(log_id, this_origin!())),
         "Explicitly allowed LogId not allowed by filter."
     );
 
     assert!(
-        filter.allow_event(&test_event(err_id, this_origin!())),
+        filter.allow_entry(&test_entry(err_id, this_origin!())),
         "Error level not allowed by filter."
     );
 
     assert!(
-        !filter.allow_event(&test_event(warn_id, this_origin!())),
+        !filter.allow_entry(&test_entry(warn_id, this_origin!())),
         "Warn level allowed by filter."
     );
 }

--- a/logid/Cargo.toml
+++ b/logid/Cargo.toml
@@ -19,6 +19,7 @@ colored = "2"
 [features]
 diagnostics = ["logid-core/diagnostics"]
 payloads = ["logid-core/payloads"]
+fmt = ["logid-core/fmt"]
 hint_note = ["logid-core/hint_note"]
 log_debugs = ["logid-core/log_debugs"]
 log_traces = ["logid-core/log_traces"]

--- a/logid/src/event_handler/builder.rs
+++ b/logid/src/event_handler/builder.rs
@@ -10,7 +10,7 @@ use std::{
 use logid_core::{
     evident::event::Event,
     log_id::{LogId, START_LOGGING, STOP_LOGGING},
-    logging::{event_entry::LogEventEntry, LOGGER},
+    logging::{event_entry::LogEventEntry, msg::LogMsg, LOGGER},
 };
 
 use super::{
@@ -27,7 +27,8 @@ pub struct AllLogs;
 #[derive(Default)]
 pub struct SpecificLogs;
 
-type Handler = Box<dyn FnMut(Arc<Event<LogId, LogEventEntry>>) + std::marker::Send + 'static>;
+type Handler =
+    Box<dyn FnMut(Arc<Event<LogId, LogMsg, LogEventEntry>>) + std::marker::Send + 'static>;
 
 #[derive(Default)]
 pub struct LogEventHandlerBuilder<K> {
@@ -54,7 +55,7 @@ impl LogEventHandlerBuilder<NoKind> {
 
     pub fn add_handler(
         mut self,
-        handler: impl FnMut(Arc<Event<LogId, LogEventEntry>>) + std::marker::Send + 'static,
+        handler: impl FnMut(Arc<Event<LogId, LogMsg, LogEventEntry>>) + std::marker::Send + 'static,
     ) -> Self {
         self.handler.push(Box::new(handler));
         self
@@ -166,9 +167,9 @@ impl std::fmt::Display for LogEventHandlerError {
     }
 }
 
-fn event_listener<F: FnMut(Arc<Event<LogId, LogEventEntry>>)>(
+fn event_listener<F: FnMut(Arc<Event<LogId, LogMsg, LogEventEntry>>)>(
     mut fns: Vec<F>,
-    recv: &Receiver<Arc<Event<LogId, LogEventEntry>>>,
+    recv: &Receiver<Arc<Event<LogId, LogMsg, LogEventEntry>>>,
     start: Arc<AtomicBool>,
     stop: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,

--- a/logid/src/event_handler/mod.rs
+++ b/logid/src/event_handler/mod.rs
@@ -35,9 +35,8 @@ impl LogEventHandler {
     pub fn start(&self) {
         self.start.store(true, Ordering::Release);
 
-        crate::evident::event::set_event_with_msg::<_, LogEventEntry, IntermediaryLogEvent>(
+        crate::evident::event::set_event::<_, _, LogEventEntry, IntermediaryLogEvent>(
             HANDLER_START_LOGGING,
-            "Start logging on handler.",
             crate::evident::this_origin!(),
         )
         .finalize();
@@ -46,9 +45,8 @@ impl LogEventHandler {
     pub fn stop(&self) {
         self.stop.store(true, Ordering::Release);
 
-        crate::evident::event::set_event_with_msg::<_, LogEventEntry, IntermediaryLogEvent>(
+        crate::evident::event::set_event::<_, _, LogEventEntry, IntermediaryLogEvent>(
             HANDLER_STOP_LOGGING,
-            "Stop logging on handler.",
             crate::evident::this_origin!(),
         )
         .finalize();
@@ -67,9 +65,8 @@ impl Drop for LogEventHandler {
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::Release);
 
-        crate::evident::event::set_event_with_msg::<_, LogEventEntry, IntermediaryLogEvent>(
+        crate::evident::event::set_event::<_, _, LogEventEntry, IntermediaryLogEvent>(
             SHUTDOWN_HANDLER,
-            "Shutdown logging on handler.",
             crate::evident::this_origin!(),
         )
         .finalize();

--- a/logid/src/event_handler/terminal.rs
+++ b/logid/src/event_handler/terminal.rs
@@ -63,14 +63,14 @@ fn terminal_writer(log_event: Arc<Event<LogId, LogEventEntry>>, to_stderr: bool)
     // Note: Addon filter is already applied on capture side, so printing what is captured is fine here
 
     for related in entry.get_related() {
-        let related_id = related.event_id;
+        let related_id = related.get_event_id();
         let related_line = format!(
             "{}{} {}: lvl='{}', {}",
             colored_lcross,
             colored_arrow,
             "Related".bold(),
             get_colored_level(related_id.get_log_level()),
-            get_event_string(&related_id, &related.entry_id.to_string()),
+            get_event_string(related_id, &related.get_entry_id().to_string()),
         );
         content_builder.add_line(related_line);
     }
@@ -238,10 +238,10 @@ fn get_colored_lbot(level: LogLevel) -> String {
     "╰".color(get_level_color(level)).to_string()
 }
 
-fn get_event_string(id: &LogId, entry_id: &str) -> String {
+fn get_event_string(id: &LogId, entry_nr: &str) -> String {
     let module = id.get_module_path();
     let identifier = id.get_identifier();
-    format!("id='{module}::{identifier}', entry='{entry_id}'")
+    format!("id='{module}::{identifier}', entry='{entry_nr}'")
 }
 
 struct ContentBuilder {

--- a/logid/src/event_handler/terminal.rs
+++ b/logid/src/event_handler/terminal.rs
@@ -158,14 +158,17 @@ fn terminal_writer(log_event: Arc<Event<LogId, LogEventEntry>>, to_stderr: bool)
     }
 
     if content_builder.lines.len() > 1 {
-        let last_line = content_builder
-            .lines
-            .remove(content_builder.lines.len() - 1);
-        content_builder.lines.push(
-            last_line
-                .replacen(&colored_lcross, &colored_lbot, 1)
-                .replacen(&colored_vbar, &colored_mbot, 1),
-        );
+        if let Some(last_line) = content_builder.lines.pop() {
+            if last_line.starts_with(&colored_lcross) {
+                content_builder
+                    .lines
+                    .push(last_line.replacen(&colored_lcross, &colored_lbot, 1));
+            } else {
+                content_builder
+                    .lines
+                    .push(last_line.replacen(&colored_vbar, &colored_mbot, 1));
+            }
+        }
     }
 
     let content_len = content_builder.content_len + content_builder.lines.len(); // + line-len for newline char

--- a/logid/src/event_handler/terminal.rs
+++ b/logid/src/event_handler/terminal.rs
@@ -92,6 +92,18 @@ fn terminal_writer(log_event: Arc<Event<LogId, LogMsg, LogEventEntry>>, to_stder
         );
     }
 
+    #[cfg(feature = "fmt")]
+    for info in entry.get_fmt_infos() {
+        content_builder.add_multiline_addon(
+            "Info",
+            info.to_string().lines(),
+            Some(get_level_color(LogLevel::Info)),
+            &colored_lcross,
+            &colored_arrow,
+            &colored_vbar,
+        );
+    }
+
     for debug in entry.get_debugs() {
         content_builder.add_multiline_addon(
             "Debug",
@@ -103,10 +115,34 @@ fn terminal_writer(log_event: Arc<Event<LogId, LogMsg, LogEventEntry>>, to_stder
         );
     }
 
+    #[cfg(feature = "fmt")]
+    for debug in entry.get_fmt_debugs() {
+        content_builder.add_multiline_addon(
+            "Debug",
+            debug.to_string().lines(),
+            Some(get_level_color(LogLevel::Debug)),
+            &colored_lcross,
+            &colored_arrow,
+            &colored_vbar,
+        );
+    }
+
     for trace in entry.get_traces() {
         content_builder.add_multiline_addon(
             "Trace",
             trace.lines(),
+            Some(get_level_color(LogLevel::Trace)),
+            &colored_lcross,
+            &colored_arrow,
+            &colored_vbar,
+        );
+    }
+
+    #[cfg(feature = "fmt")]
+    for trace in entry.get_fmt_traces() {
+        content_builder.add_multiline_addon(
+            "Trace",
+            trace.to_string().lines(),
             Some(get_level_color(LogLevel::Trace)),
             &colored_lcross,
             &colored_arrow,
@@ -126,6 +162,18 @@ fn terminal_writer(log_event: Arc<Event<LogId, LogMsg, LogEventEntry>>, to_stder
         );
     }
 
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    for hint in entry.get_fmt_hints() {
+        content_builder.add_multiline_addon(
+            "Hint",
+            hint.to_string().lines(),
+            Some(Color::Cyan),
+            &colored_lcross,
+            &colored_arrow,
+            &colored_vbar,
+        );
+    }
+
     #[cfg(feature = "hint_note")]
     for note in entry.get_notes() {
         content_builder.add_multiline_addon(
@@ -138,12 +186,24 @@ fn terminal_writer(log_event: Arc<Event<LogId, LogMsg, LogEventEntry>>, to_stder
         );
     }
 
-    #[cfg(feature = "diagnostics")]
-    for diag in entry.get_diagnostics() {
-        // TODO: make diag output prettier
+    #[cfg(all(feature = "hint_note", feature = "fmt"))]
+    for note in entry.get_fmt_notes() {
+        content_builder.add_multiline_addon(
+            "Note",
+            note.to_string().lines(),
+            Some(Color::Cyan),
+            &colored_lcross,
+            &colored_arrow,
+            &colored_vbar,
+        );
+    }
+
+    // Note: Only formatted diag output, because non-formatted is too much clutter
+    #[cfg(all(feature = "diagnostics", feature = "fmt"))]
+    for diag in entry.get_fmt_diagnostics() {
         content_builder.add_multiline_addon(
             "Diagnostics",
-            diag.message.lines(),
+            diag.to_string().lines(),
             None,
             &colored_lcross,
             &colored_arrow,
@@ -153,6 +213,18 @@ fn terminal_writer(log_event: Arc<Event<LogId, LogMsg, LogEventEntry>>, to_stder
 
     #[cfg(feature = "payloads")]
     for payload in entry.get_payloads() {
+        content_builder.add_multiline_addon(
+            "Payload",
+            payload.to_string().lines(),
+            None,
+            &colored_lcross,
+            &colored_arrow,
+            &colored_vbar,
+        );
+    }
+
+    #[cfg(all(feature = "payloads", feature = "fmt"))]
+    for payload in entry.get_fmt_payloads() {
         content_builder.add_multiline_addon(
             "Payload",
             payload.to_string().lines(),

--- a/logid/src/macros.rs
+++ b/logid/src/macros.rs
@@ -25,6 +25,14 @@ macro_rules! log {
     ($any:expr, $msg:expr, $(add:$addon:expr),*) => {
         $crate::set_event!(($any).into(), $msg)$(.add_addon($addon))*.finalize()
     };
+
+    // Note: It is not possible to check for "fmt" feature flag here
+    ($any:expr, $fmt_fn:expr, $fmt_data:expr) => {
+        $crate::set_event!(($any).into(), $crate::logging::msg::FmtMsg::new($fmt_fn, $fmt_data)).finalize()
+    };
+    ($any:expr, $fmt_fn:expr, $fmt_data:expr, $(add:$addon:expr),*) => {
+        $crate::set_event!(($any).into(), $crate::logging::msg::FmtMsg::new($fmt_fn, $fmt_data))$(.add_addon($addon))*.finalize()
+    };
 }
 
 #[macro_export]
@@ -53,6 +61,19 @@ macro_rules! err {
             Err($error)
         }
     };
+
+    ($error:expr, $fmt_fn:expr, $fmt_data:expr) => {
+        {
+            $crate::log!($error, $fmt_fn, $fmt_data);
+            Err($error)
+        }
+    };
+    ($error:expr, $fmt_fn:expr, $fmt_data:expr, $(add:$addon:expr),*) => {
+        {
+            $crate::log!($error, $fmt_fn, $fmt_data, $(add:$addon),*);
+            Err($error)
+        }
+    };
 }
 
 #[macro_export]
@@ -78,6 +99,19 @@ macro_rules! pipe {
     ($any:expr, $msg:expr, $(add:$addon:expr),*) => {
         {
             $crate::log!($any, $msg, $(add:$addon),*);
+            $any
+        }
+    };
+
+    ($any:expr, $fmt_fn:expr, $fmt_data:expr) => {
+        {
+            $crate::log!($any, $fmt_fn, $fmt_data);
+            $any
+        }
+    };
+    ($any:expr, $fmt_fn:expr, $fmt_data:expr, $(add:$addon:expr),*) => {
+        {
+            $crate::log!($any, $fmt_fn, $fmt_data, $(add:$addon),*);
             $any
         }
     };

--- a/logid/src/macros.rs
+++ b/logid/src/macros.rs
@@ -1,5 +1,6 @@
 crate::evident::create_set_event_macro!(
     id_type = logid::log_id::LogId,
+    msg_type = logid::logging::msg::LogMsg,
     entry_type = logid::logging::event_entry::LogEventEntry,
     interm_event_type = logid::logging::intermediary_event::IntermediaryLogEvent
 );
@@ -7,10 +8,16 @@ crate::evident::create_set_event_macro!(
 #[macro_export]
 macro_rules! log {
     ($any:expr) => {
-        $crate::set_event!(($any).clone().into(), &$any.to_string()).finalize()
+        {
+            let s = $any.to_string();
+            $crate::set_event!(($any).into(), s).finalize()
+        }
     };
     ($any:expr, $(add:$addon:expr),*) => {
-        $crate::set_event!(($any).into(), &$any.to_string())$(.add_addon($addon))*.finalize()
+        {
+            let s = $any.to_string();
+            $crate::set_event!(($any).into(), s)$(.add_addon($addon))*.finalize()
+        }
     };
     ($any:expr, $msg:expr) => {
         $crate::set_event!(($any).into(), $msg).finalize()

--- a/logid/tests/default_set_events.rs
+++ b/logid/tests/default_set_events.rs
@@ -48,12 +48,7 @@ fn capture_single_logid() {
     );
     assert_eq!(
         *entry.get_origin(),
-        Origin::new(
-            env!("CARGO_PKG_NAME"),
-            module_path!(),
-            file!(),
-            line!() - 29
-        ), //Note: Event is set 29 lines above
+        Origin::new(module_path!(), file!(), line!() - 25), //Note: Event is set 25 lines above
         "Set and stored origins are not equal"
     );
 }

--- a/logid/tests/default_set_events.rs
+++ b/logid/tests/default_set_events.rs
@@ -42,7 +42,7 @@ fn capture_single_logid() {
         "Set and stored event levels are not equal"
     );
     assert_eq!(
-        *entry.get_msg(),
+        entry.get_msg().unwrap(),
         msg,
         "Set and stored messages are not equal"
     );
@@ -83,7 +83,7 @@ fn set_event_for_err_result() {
         "Set and stored log-ids are not equal"
     );
     assert_eq!(
-        *entry.get_msg(),
+        entry.get_msg().unwrap(),
         msg,
         "Set and stored messages are not equal"
     );
@@ -116,7 +116,7 @@ fn capture_logid_with_custom_identifier() {
         "Set and stored event levels are not equal"
     );
     assert_eq!(
-        *entry.get_msg(),
+        entry.get_msg().unwrap(),
         msg,
         "Set and stored messages are not equal"
     );

--- a/logid/tests/fmt_msg.rs
+++ b/logid/tests/fmt_msg.rs
@@ -1,0 +1,114 @@
+#[cfg(feature = "fmt")]
+mod fmt_tests {
+    use std::error::Error;
+
+    use logid::{err, log, pipe};
+    use logid_core::{
+        evident::event::entry::EventEntry,
+        log_id::{LogId, LogLevel},
+        logging::LOGGER,
+        new_log_id,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Copy)]
+    struct TestDummy {}
+
+    impl std::fmt::Display for TestDummy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "TestDummy")
+        }
+    }
+
+    impl Error for TestDummy {}
+
+    impl From<TestDummy> for LogId {
+        fn from(_value: TestDummy) -> Self {
+            new_log_id!("TestDummy", LogLevel::Error)
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct MsgData {
+        val: String,
+    }
+
+    fn fmt_msg(data: &serde_json::Value) -> String {
+        data.to_string()
+    }
+
+    #[test]
+    fn log_with_fmt_msg() {
+        let dummy = TestDummy {};
+        let test_data = MsgData {
+            val: "Log".to_string(),
+        };
+
+        let recv = LOGGER.subscribe(dummy.into()).unwrap();
+
+        let ser: serde_json::Value = serde_json::to_value(test_data).unwrap();
+        log!(dummy, fmt_msg, ser.clone());
+
+        let event = recv
+            .get_receiver()
+            .recv_timeout(std::time::Duration::from_millis(10))
+            .unwrap();
+
+        let entry = event.get_entry();
+        assert_eq!(
+            entry.get_msg().unwrap(),
+            &fmt_msg(&ser),
+            "Formatted msg was not stored in the entry"
+        );
+    }
+
+    #[test]
+    fn err_with_fmt_msg() {
+        let dummy = TestDummy {};
+        let test_data = MsgData {
+            val: "Error".to_string(),
+        };
+
+        let recv = LOGGER.subscribe(dummy.into()).unwrap();
+
+        let ser: serde_json::Value = serde_json::to_value(test_data).unwrap();
+        let _: Result<(), _> = err!(dummy, fmt_msg, ser.clone());
+
+        let event = recv
+            .get_receiver()
+            .recv_timeout(std::time::Duration::from_millis(10))
+            .unwrap();
+
+        let entry = event.get_entry();
+        assert_eq!(
+            entry.get_msg().unwrap(),
+            &fmt_msg(&ser),
+            "Formatted msg was not stored in the entry"
+        );
+    }
+
+    #[test]
+    fn pipe_with_fmt_msg() {
+        let dummy = TestDummy {};
+        let test_data = MsgData {
+            val: "Pipe".to_string(),
+        };
+
+        let recv = LOGGER.subscribe(dummy.into()).unwrap();
+
+        let ser: serde_json::Value = serde_json::to_value(test_data).unwrap();
+        let _ = pipe!(dummy, fmt_msg, ser.clone());
+
+        let event = recv
+            .get_receiver()
+            .recv_timeout(std::time::Duration::from_millis(10))
+            .unwrap();
+
+        let entry = event.get_entry();
+        assert_eq!(
+            entry.get_msg().unwrap(),
+            &fmt_msg(&ser),
+            "Formatted msg was not stored in the entry"
+        );
+    }
+}

--- a/logid/tests/fmt_msg.rs
+++ b/logid/tests/fmt_msg.rs
@@ -5,6 +5,7 @@ mod fmt_tests {
     use logid::{err, log, pipe};
     use logid_core::{
         evident::event::entry::EventEntry,
+        info_addon,
         log_id::{LogId, LogLevel},
         logging::LOGGER,
         new_log_id,
@@ -109,6 +110,31 @@ mod fmt_tests {
             entry.get_msg().unwrap(),
             &fmt_msg(&ser),
             "Formatted msg was not stored in the entry"
+        );
+    }
+
+    #[test]
+    fn log_with_fmt_info_addon() {
+        let dummy = TestDummy {};
+        let test_data = MsgData {
+            val: "InfoAddon".to_string(),
+        };
+
+        let recv = LOGGER.subscribe(dummy.into()).unwrap();
+
+        let ser: serde_json::Value = serde_json::to_value(test_data).unwrap();
+        log!(dummy, "dummy msg", add: info_addon!(fmt_msg, ser.clone()));
+
+        let event = recv
+            .get_receiver()
+            .recv_timeout(std::time::Duration::from_millis(10))
+            .unwrap();
+
+        let entry = event.get_entry();
+        assert_eq!(
+            entry.get_fmt_infos().first().unwrap().to_string(),
+            fmt_msg(&ser),
+            "Formatted info addon was not stored in the entry"
         );
     }
 }


### PR DESCRIPTION
closes #22 

This PR adds the `fmt` feature flag allowing to set `FmtMsg` as log message.
This formatted message takes serialized data and a function that converts this data to a string.
The function is used to write the formatted data to the terminal.

At the moment, the function must be given as function pointer, because `FnMut` could not be executed if `FmtMsg` was only given as reference.