### PR TITLE
fix: use types for filter construction [WIP]

### DIFF
--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -1,6 +1,7 @@
 use criterion::{black_box, Criterion};
 use criterion::{criterion_group, criterion_main};
-use logid::logging::LOGGER;
+use logid::logging::filter::AddonFilter;
+use logid::logging::{filter, LOGGER};
 use logid::{
     err, event_handler::builder::LogEventHandlerBuilder, log, log_id::LogLevel,
     logging::event_entry::AddonKind, DbgLogId, ErrLogId, InfoLogId, TraceLogId, WarnLogId,
@@ -60,7 +61,7 @@ pub fn bench_compare_advanced_logging(c: &mut Criterion) {
         .with_max_level(LevelFilter::DEBUG)
         .init();
 
-    let _ = logid::set_filter!("debug(infos)");
+    let _ = filter::set_filter((LogLevel::Debug, AddonFilter::Infos));
 
     let _log_handler = LogEventHandlerBuilder::new()
         .to_stderr()

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -2,13 +2,15 @@ use logid::{
     err,
     event_handler::builder::LogEventHandlerBuilder,
     log,
-    logging::{event_entry::AddonKind, LOGGER},
+    log_id::LogLevel,
+    logging::{event_entry::AddonKind, filter::AddonFilter, LOGGER},
     payload_addon, DbgLogId, ErrLogId, InfoLogId, TraceLogId, WarnLogId,
 };
 use serde::{Deserialize, Serialize};
 
 fn main() {
-    let _ = logid::set_filter!("trace(all)");
+    let _ = logid::logging::filter::set_filter((LogLevel::Trace, AddonFilter::AllAllowed));
+    let _ = logid::logging::filter::set_filter(logid::filter!(Trace(AllAllowed)));
 
     let handler = LogEventHandlerBuilder::new()
         .to_stderr()

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 
 fn main() {
     let _ = logid::logging::filter::set_filter((LogLevel::Trace, AddonFilter::AllAllowed));
-    let _ = logid::logging::filter::set_filter(logid::filter!(Trace(AllAllowed)));
 
     let handler = LogEventHandlerBuilder::new()
         .to_stderr()

--- a/core/src/log_id.rs
+++ b/core/src/log_id.rs
@@ -71,7 +71,7 @@ impl std::fmt::Display for LogId {
 }
 
 /// Log level a [`LogId`] may represent.
-#[derive(Debug, Default, PartialOrd, PartialEq, Eq, Clone, Copy, std::hash::Hash)]
+#[derive(Debug, Default, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, std::hash::Hash)]
 pub enum LogLevel {
     Trace = 0,
     #[default]

--- a/core/src/logging/filter/filter_builders.rs
+++ b/core/src/logging/filter/filter_builders.rs
@@ -4,8 +4,7 @@ use super::{AddonFilter, FilterConfig, LogIdAddonFilter, LogIdModuleFilter};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FilterConfigBuilder {
-    // TODO: negation is confusing, use affirmation instead (no_general_logging -> general_logging)
-    no_general_logging: bool,
+    logging_enabled: bool,
     general_level: LogLevel,
     general_addons: Vec<AddonFilter>,
     /// LogIds set with `on[LogId]`
@@ -14,6 +13,7 @@ pub struct FilterConfigBuilder {
 }
 
 impl FilterConfigBuilder {
+    /// Creates a new builder for [`FilterConfig`].
     pub fn new(level: LogLevel) -> Self {
         Self {
             general_level: level,
@@ -21,16 +21,13 @@ impl FilterConfigBuilder {
         }
     }
 
-    pub fn level(mut self, level: LogLevel) -> Self {
-        self.general_level = level;
+    /// Disable logging in general.
+    pub fn disabled_logging(mut self) -> Self {
+        self.logging_enabled = false;
         self
     }
 
-    pub fn no_general_logging(mut self) -> Self {
-        self.no_general_logging = true;
-        self
-    }
-
+    /// Add addons allowed by the filter.
     pub fn allowed_addons<I>(mut self, addons: I) -> Self
     where
         I: IntoIterator,
@@ -41,6 +38,7 @@ impl FilterConfigBuilder {
         self
     }
 
+    /// Add LogIDs allowed by the filter.
     pub fn global_ids<I>(mut self, global_ids: I) -> Self
     where
         I: IntoIterator,
@@ -51,6 +49,7 @@ impl FilterConfigBuilder {
         self
     }
 
+    /// Add modules allowed by the filter.
     pub fn modules<I>(mut self, modules: I) -> Self
     where
         I: IntoIterator,
@@ -61,9 +60,10 @@ impl FilterConfigBuilder {
         self
     }
 
+    /// Build [`FilterConfig`] with configuration constructed using the builder.
     pub fn build(self) -> FilterConfig {
         FilterConfig {
-            no_general_logging: self.no_general_logging,
+            logging_enabled: self.logging_enabled,
             general_level: self.general_level,
             general_addons: self.general_addons,
             allowed_global_ids: self.allowed_global_ids,

--- a/core/src/logging/filter/filter_builders.rs
+++ b/core/src/logging/filter/filter_builders.rs
@@ -31,7 +31,7 @@ impl FilterConfigBuilder {
         self
     }
 
-    pub fn addons<I>(mut self, addons: I) -> Self
+    pub fn allowed_addons<I>(mut self, addons: I) -> Self
     where
         I: IntoIterator,
         I::Item: Into<AddonFilter>,

--- a/core/src/logging/filter/filter_builders.rs
+++ b/core/src/logging/filter/filter_builders.rs
@@ -1,0 +1,67 @@
+use crate::log_id::LogLevel;
+
+use super::{AddonFilter, FilterConfig, LogIdAddonFilter, LogIdModuleFilter};
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FilterConfigBuilder {
+    // TODO: negation is confusing, use affirmation instead (no_general_logging -> general_logging)
+    no_general_logging: bool,
+    general_level: LogLevel,
+    general_addons: Vec<AddonFilter>,
+    /// LogIds set with `on[LogId]`
+    allowed_global_ids: Vec<LogIdAddonFilter>,
+    allowed_modules: Vec<LogIdModuleFilter>,
+}
+
+impl FilterConfigBuilder {
+    pub fn new(level: LogLevel) -> Self {
+        Self {
+            general_level: level,
+            ..Default::default()
+        }
+    }
+
+    pub fn level(mut self, level: LogLevel) -> Self {
+        self.general_level = level;
+        self
+    }
+
+    pub fn no_general_logging(mut self) -> Self {
+        self.no_general_logging = true;
+        self
+    }
+
+    pub fn addons<T>(mut self, addons: T) -> Self
+    where
+        T: IntoIterator<Item = AddonFilter>,
+    {
+        self.general_addons.extend(addons.into_iter());
+        self
+    }
+
+    pub fn global_ids<T>(mut self, global_ids: T) -> Self
+    where
+        T: IntoIterator<Item = LogIdAddonFilter>,
+    {
+        self.allowed_global_ids.extend(global_ids.into_iter());
+        self
+    }
+
+    pub fn modules<T>(mut self, modules: T) -> Self
+    where
+        T: IntoIterator<Item = LogIdModuleFilter>,
+    {
+        self.allowed_modules.extend(modules.into_iter());
+        self
+    }
+
+    pub fn build(self) -> FilterConfig {
+        FilterConfig {
+            no_general_logging: self.no_general_logging,
+            general_level: self.general_level,
+            general_addons: self.general_addons,
+            allowed_global_ids: self.allowed_global_ids,
+            allowed_modules: self.allowed_modules,
+        }
+    }
+}

--- a/core/src/logging/filter/filter_builders.rs
+++ b/core/src/logging/filter/filter_builders.rs
@@ -4,7 +4,7 @@ use super::{AddonFilter, FilterConfig, LogIdAddonFilter, LogIdModuleFilter};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FilterConfigBuilder {
-    logging_enabled: bool,
+    general_logging_enabled: bool,
     general_level: LogLevel,
     general_addons: Vec<AddonFilter>,
     /// LogIds set with `on[LogId]`
@@ -22,8 +22,8 @@ impl FilterConfigBuilder {
     }
 
     /// Disable logging in general.
-    pub fn disabled_logging(mut self) -> Self {
-        self.logging_enabled = false;
+    pub fn disabled_general_logging(mut self) -> Self {
+        self.general_logging_enabled = false;
         self
     }
 
@@ -63,7 +63,7 @@ impl FilterConfigBuilder {
     /// Build [`FilterConfig`] with configuration constructed using the builder.
     pub fn build(self) -> FilterConfig {
         FilterConfig {
-            logging_enabled: self.logging_enabled,
+            general_logging_enabled: self.general_logging_enabled,
             general_level: self.general_level,
             general_addons: self.general_addons,
             allowed_global_ids: self.allowed_global_ids,

--- a/core/src/logging/filter/filter_builders.rs
+++ b/core/src/logging/filter/filter_builders.rs
@@ -31,27 +31,33 @@ impl FilterConfigBuilder {
         self
     }
 
-    pub fn addons<T>(mut self, addons: T) -> Self
+    pub fn addons<I>(mut self, addons: I) -> Self
     where
-        T: IntoIterator<Item = AddonFilter>,
+        I: IntoIterator,
+        I::Item: Into<AddonFilter>,
     {
-        self.general_addons.extend(addons.into_iter());
+        self.general_addons
+            .extend(addons.into_iter().map(Into::into));
         self
     }
 
-    pub fn global_ids<T>(mut self, global_ids: T) -> Self
+    pub fn global_ids<I>(mut self, global_ids: I) -> Self
     where
-        T: IntoIterator<Item = LogIdAddonFilter>,
+        I: IntoIterator,
+        I::Item: Into<LogIdAddonFilter>,
     {
-        self.allowed_global_ids.extend(global_ids.into_iter());
+        self.allowed_global_ids
+            .extend(global_ids.into_iter().map(Into::into));
         self
     }
 
-    pub fn modules<T>(mut self, modules: T) -> Self
+    pub fn modules<I>(mut self, modules: I) -> Self
     where
-        T: IntoIterator<Item = LogIdModuleFilter>,
+        I: IntoIterator,
+        I::Item: Into<LogIdModuleFilter>,
     {
-        self.allowed_modules.extend(modules.into_iter());
+        self.allowed_modules
+            .extend(modules.into_iter().map(Into::into));
         self
     }
 

--- a/core/src/logging/filter/mod.rs
+++ b/core/src/logging/filter/mod.rs
@@ -285,6 +285,16 @@ pub struct LogIdAddonFilter {
     allowed_addons: Vec<AddonFilter>,
 }
 
+impl IntoIterator for LogIdAddonFilter {
+    type Item = Self;
+
+    type IntoIter = std::iter::Once<Self>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(self)
+    }
+}
+
 impl TryFrom<&str> for LogIdAddonFilter {
     type Error = FilterError;
 
@@ -306,6 +316,16 @@ pub struct LogIdModuleFilter {
     level: LogLevel,
     allowed_ids: Vec<LogIdAddonFilter>,
     allowed_addons: Vec<AddonFilter>,
+}
+
+impl IntoIterator for LogIdModuleFilter {
+    type Item = Self;
+
+    type IntoIter = std::iter::Once<Self>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(self)
+    }
 }
 
 impl LogIdModuleFilter {

--- a/core/src/logging/filter/mod.rs
+++ b/core/src/logging/filter/mod.rs
@@ -403,7 +403,7 @@ impl LogIdModuleFilter {
 
 #[derive(Default, Debug)]
 pub struct FilterConfig {
-    logging_enabled: bool,
+    general_logging_enabled: bool,
     general_level: LogLevel,
     general_addons: Vec<AddonFilter>,
     /// LogIds set with `on[LogId]`
@@ -415,13 +415,13 @@ impl FilterConfig {
     pub fn new(filter: &str) -> Self {
         if filter.trim().is_empty() || filter.to_lowercase() == "off" {
             return FilterConfig {
-                logging_enabled: false,
+                general_logging_enabled: false,
                 ..Default::default()
             };
         }
 
         let mut log_filter = FilterConfig {
-            logging_enabled: false,
+            general_logging_enabled: false,
             general_level: LogLevel::Error,
             general_addons: Vec::new(),
             allowed_global_ids: Vec::new(),
@@ -439,7 +439,7 @@ impl FilterConfig {
                 let addons = get_addons(&mut stripped_filter_part);
 
                 if let Some(general_level) = try_into_log_level(stripped_filter_part.trim()) {
-                    log_filter.logging_enabled = true;
+                    log_filter.general_logging_enabled = true;
                     log_filter.general_level = general_level;
                     log_filter.general_addons = addons;
                 } else if let Ok(module_filter) =
@@ -458,13 +458,13 @@ impl FilterConfig {
         self.allowed_modules = other.allowed_modules;
         self.general_addons = other.general_addons;
         self.general_level = other.general_level;
-        self.logging_enabled = other.logging_enabled;
+        self.general_logging_enabled = other.general_logging_enabled;
     }
 
     pub fn allow_addon(&self, id: LogId, origin: &Origin, addon: &AddonKind) -> bool {
         let addon_filter = AddonFilter::from(addon);
 
-        if self.logging_enabled && self.general_addons.contains(&addon_filter) {
+        if self.general_logging_enabled && self.general_addons.contains(&addon_filter) {
             return true;
         }
 
@@ -475,7 +475,7 @@ impl FilterConfig {
     pub fn show_origin_info(&self, id: LogId, origin: &Origin) -> bool {
         let addon_filter = AddonFilter::Origin;
 
-        if self.logging_enabled && self.general_addons.contains(&addon_filter) {
+        if self.general_logging_enabled && self.general_addons.contains(&addon_filter) {
             return true;
         }
 
@@ -486,7 +486,7 @@ impl FilterConfig {
     pub fn show_id(&self, id: LogId, origin: &Origin) -> bool {
         let addon_filter = AddonFilter::Id;
 
-        if self.logging_enabled && self.general_addons.contains(&addon_filter) {
+        if self.general_logging_enabled && self.general_addons.contains(&addon_filter) {
             return true;
         }
 
@@ -511,7 +511,7 @@ impl evident::event::filter::Filter<LogId, LogMsg> for FilterConfig {
         }
 
         // Note: `Trace` starts at `0`
-        if self.logging_enabled && self.general_level <= entry.get_event_id().log_level {
+        if self.general_logging_enabled && self.general_level <= entry.get_event_id().log_level {
             return true;
         }
 

--- a/core/src/logging/filter/mod.rs
+++ b/core/src/logging/filter/mod.rs
@@ -45,7 +45,10 @@ impl LogFilter {
             Ok(mut locked_filter) => {
                 locked_filter.replace(filter_config);
             }
-            Err(_) => todo!(),
+            Err(mut err) => {
+                // lock poisoned, replace inner filter completely
+                **err.get_mut() = filter_config;
+            }
         }
 
         Ok(())

--- a/core/src/logging/filter/mod.rs
+++ b/core/src/logging/filter/mod.rs
@@ -494,8 +494,8 @@ impl FilterConfig {
             || addon_allowed_in_origin(&self.allowed_modules, id, origin, &addon_filter)
     }
 
-    pub fn builder() -> FilterConfigBuilder {
-        FilterConfigBuilder::new(LogLevel::Error)
+    pub fn builder(log_level: LogLevel) -> FilterConfigBuilder {
+        FilterConfigBuilder::new(log_level)
     }
 }
 
@@ -529,7 +529,7 @@ where
     I: IntoIterator<Item = AddonFilter>,
 {
     fn from((level, addons): (LogLevel, I)) -> Self {
-        FilterConfig::builder().level(level).addons(addons).build()
+        FilterConfig::builder(level).allowed_addons(addons).build()
     }
 }
 

--- a/core/src/logging/filter/mod.rs
+++ b/core/src/logging/filter/mod.rs
@@ -403,7 +403,7 @@ impl LogIdModuleFilter {
 
 #[derive(Default, Debug)]
 pub struct FilterConfig {
-    no_general_logging: bool,
+    logging_enabled: bool,
     general_level: LogLevel,
     general_addons: Vec<AddonFilter>,
     /// LogIds set with `on[LogId]`
@@ -415,13 +415,13 @@ impl FilterConfig {
     pub fn new(filter: &str) -> Self {
         if filter.trim().is_empty() || filter.to_lowercase() == "off" {
             return FilterConfig {
-                no_general_logging: true,
+                logging_enabled: false,
                 ..Default::default()
             };
         }
 
         let mut log_filter = FilterConfig {
-            no_general_logging: true,
+            logging_enabled: false,
             general_level: LogLevel::Error,
             general_addons: Vec::new(),
             allowed_global_ids: Vec::new(),
@@ -439,7 +439,7 @@ impl FilterConfig {
                 let addons = get_addons(&mut stripped_filter_part);
 
                 if let Some(general_level) = try_into_log_level(stripped_filter_part.trim()) {
-                    log_filter.no_general_logging = false;
+                    log_filter.logging_enabled = true;
                     log_filter.general_level = general_level;
                     log_filter.general_addons = addons;
                 } else if let Ok(module_filter) =
@@ -458,13 +458,13 @@ impl FilterConfig {
         self.allowed_modules = other.allowed_modules;
         self.general_addons = other.general_addons;
         self.general_level = other.general_level;
-        self.no_general_logging = other.no_general_logging;
+        self.logging_enabled = other.logging_enabled;
     }
 
     pub fn allow_addon(&self, id: LogId, origin: &Origin, addon: &AddonKind) -> bool {
         let addon_filter = AddonFilter::from(addon);
 
-        if !self.no_general_logging && self.general_addons.contains(&addon_filter) {
+        if self.logging_enabled && self.general_addons.contains(&addon_filter) {
             return true;
         }
 
@@ -475,7 +475,7 @@ impl FilterConfig {
     pub fn show_origin_info(&self, id: LogId, origin: &Origin) -> bool {
         let addon_filter = AddonFilter::Origin;
 
-        if !self.no_general_logging && self.general_addons.contains(&addon_filter) {
+        if self.logging_enabled && self.general_addons.contains(&addon_filter) {
             return true;
         }
 
@@ -486,7 +486,7 @@ impl FilterConfig {
     pub fn show_id(&self, id: LogId, origin: &Origin) -> bool {
         let addon_filter = AddonFilter::Id;
 
-        if !self.no_general_logging && self.general_addons.contains(&addon_filter) {
+        if self.logging_enabled && self.general_addons.contains(&addon_filter) {
             return true;
         }
 
@@ -511,7 +511,7 @@ impl evident::event::filter::Filter<LogId, LogMsg> for FilterConfig {
         }
 
         // Note: `Trace` starts at `0`
-        if !self.no_general_logging && self.general_level <= entry.get_event_id().log_level {
+        if self.logging_enabled && self.general_level <= entry.get_event_id().log_level {
             return true;
         }
 

--- a/core/src/logging/tests/filter/addons.rs
+++ b/core/src/logging/tests/filter/addons.rs
@@ -1,7 +1,7 @@
 use crate::{
     log_id::LogLevel,
     logging::{
-        event_entry::AddonKind, filter::InnerLogFilter, intermediary_event::IntermediaryLogEvent,
+        event_entry::AddonKind, filter::FilterConfig, intermediary_event::IntermediaryLogEvent,
         msg::NO_MSG, tests::filter::test_entry,
     },
     new_log_id,
@@ -14,7 +14,7 @@ use evident::{
 #[test]
 fn allow_single_id_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on[{}::{}(infos)]",
         log_id.get_module_path(),
         log_id.get_identifier()
@@ -38,7 +38,7 @@ fn allow_single_id_with_infos_addon() {
 #[test]
 fn allow_single_id_with_infos_and_origin_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on[{}::{}(infos & origin)]",
         log_id.get_module_path(),
         log_id.get_identifier()
@@ -67,7 +67,7 @@ fn allow_single_id_with_infos_and_origin_addon() {
 #[test]
 fn allow_single_id_with_related_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on[{}::{}(related)]",
         log_id.get_module_path(),
         log_id.get_identifier()
@@ -89,7 +89,7 @@ fn allow_single_id_with_related_addon() {
 #[test]
 fn allow_single_id_with_all_addons() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on[{}::{}(all)]",
         log_id.get_module_path(),
         log_id.get_identifier()
@@ -160,7 +160,7 @@ fn allow_single_id_with_all_addons() {
 #[test]
 fn allow_module_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
-    let filter = InnerLogFilter::new("logid_core::logging(infos) = error");
+    let filter = FilterConfig::new("logid_core::logging(infos) = error");
 
     assert!(
         filter.allow_entry(&test_entry(log_id, this_origin!())),
@@ -180,7 +180,7 @@ fn allow_module_with_infos_addon() {
 #[test]
 fn allow_crate_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
-    let filter = InnerLogFilter::new("logid_core(infos) = error");
+    let filter = FilterConfig::new("logid_core(infos) = error");
 
     assert!(
         filter.allow_entry(&test_entry(log_id, this_origin!())),
@@ -200,7 +200,7 @@ fn allow_crate_with_infos_addon() {
 #[test]
 fn allow_general_level_with_infos_addon() {
     let log_id = new_log_id!("log_id", LogLevel::Error);
-    let filter = InnerLogFilter::new("error(infos)");
+    let filter = FilterConfig::new("error(infos)");
 
     assert!(
         filter.allow_entry(&test_entry(log_id, this_origin!())),

--- a/core/src/logging/tests/filter/global_ids.rs
+++ b/core/src/logging/tests/filter/global_ids.rs
@@ -1,6 +1,6 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_entry},
+    logging::{filter::FilterConfig, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
@@ -8,7 +8,7 @@ use evident::{event::filter::Filter, this_origin};
 #[test]
 fn allow_single_id() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on[{}::{}]",
         log_id.get_module_path(),
         log_id.get_identifier()
@@ -25,7 +25,7 @@ fn allow_multiple_ids() {
     let log_id_1 = new_log_id!("log_id_1", LogLevel::Info);
     let log_id_2 = new_log_id!("log_id_2", LogLevel::Debug);
 
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on[{}::{} | {}::{}]",
         log_id_1.get_module_path(),
         log_id_1.get_identifier(),
@@ -48,7 +48,7 @@ fn allow_multiple_ids() {
 fn invalid_ids_syntax() {
     let log_id = new_log_id!("log_id", LogLevel::Info);
 
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on]{}::{}[",
         log_id.get_module_path(),
         log_id.get_identifier(),

--- a/core/src/logging/tests/filter/only_general.rs
+++ b/core/src/logging/tests/filter/only_general.rs
@@ -1,13 +1,13 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_entry},
+    logging::{filter::FilterConfig, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
 
 #[test]
 fn logging_turned_off() {
-    let filter = InnerLogFilter::new("off");
+    let filter = FilterConfig::new("off");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
 
@@ -19,7 +19,7 @@ fn logging_turned_off() {
 
 #[test]
 fn empty_filter_means_logging_turned_off() {
-    let filter = InnerLogFilter::new("");
+    let filter = FilterConfig::new("");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
 
@@ -31,7 +31,7 @@ fn empty_filter_means_logging_turned_off() {
 
 #[test]
 fn only_allow_error() {
-    let filter = InnerLogFilter::new("error");
+    let filter = FilterConfig::new("error");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
@@ -48,7 +48,7 @@ fn only_allow_error() {
 
 #[test]
 fn allow_error_and_warning() {
-    let filter = InnerLogFilter::new("warn");
+    let filter = FilterConfig::new("warn");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
@@ -71,7 +71,7 @@ fn allow_error_and_warning() {
 
 #[test]
 fn allow_error_warning_and_info() {
-    let filter = InnerLogFilter::new("info");
+    let filter = FilterConfig::new("info");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
@@ -100,7 +100,7 @@ fn allow_error_warning_and_info() {
 
 #[test]
 fn allow_error_warning_info_and_debug() {
-    let filter = InnerLogFilter::new("debug");
+    let filter = FilterConfig::new("debug");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
@@ -135,7 +135,7 @@ fn allow_error_warning_info_and_debug() {
 
 #[test]
 fn allow_error_warning_info_debug_and_trace() {
-    let filter = InnerLogFilter::new("trace");
+    let filter = FilterConfig::new("trace");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(
@@ -170,7 +170,7 @@ fn allow_error_warning_info_debug_and_trace() {
 
 #[test]
 fn logging_on_equal_to_trace() {
-    let filter = InnerLogFilter::new("on");
+    let filter = FilterConfig::new("on");
 
     let error_id = new_log_id!("err_id", LogLevel::Error);
     assert!(

--- a/core/src/logging/tests/filter/only_module.rs
+++ b/core/src/logging/tests/filter/only_module.rs
@@ -1,13 +1,13 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_entry},
+    logging::{filter::FilterConfig, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
 
 #[test]
 fn single_module() {
-    let filter = InnerLogFilter::new("logid_core::logging = warn");
+    let filter = FilterConfig::new("logid_core::logging = warn");
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
@@ -24,7 +24,7 @@ fn single_module() {
 
 #[test]
 fn only_crate_name_as_module() {
-    let filter = InnerLogFilter::new("logid_core = warn");
+    let filter = FilterConfig::new("logid_core = warn");
 
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
     assert!(
@@ -41,7 +41,7 @@ fn only_crate_name_as_module() {
 
 #[test]
 fn multiple_modules() {
-    let filter = InnerLogFilter::new(
+    let filter = FilterConfig::new(
         "logid_core::logging::tests = warn, logid_core::logging::event_entry = info",
     );
 
@@ -60,7 +60,7 @@ fn multiple_modules() {
 
 #[test]
 fn module_with_id() {
-    let filter = InnerLogFilter::new(
+    let filter = FilterConfig::new(
         "logid_core::logging[logid_core::logging::tests::filter::only_module::info_id] = error",
     );
 
@@ -79,7 +79,7 @@ fn module_with_id() {
 
 #[test]
 fn module_with_id_allowed_only() {
-    let filter = InnerLogFilter::new(
+    let filter = FilterConfig::new(
         "logid_core::logging[logid_core::logging::tests::filter::only_module::info_id]",
     );
 

--- a/core/src/logging/tests/filter/rule_mix.rs
+++ b/core/src/logging/tests/filter/rule_mix.rs
@@ -1,6 +1,6 @@
 use crate::{
     log_id::LogLevel,
-    logging::{filter::InnerLogFilter, tests::filter::test_entry},
+    logging::{filter::FilterConfig, tests::filter::test_entry},
     new_log_id,
 };
 use evident::{event::filter::Filter, this_origin};
@@ -11,7 +11,7 @@ fn global_id_and_general_error() {
     let err_id = new_log_id!("err_id", LogLevel::Error);
     let warn_id = new_log_id!("warn_id", LogLevel::Warn);
 
-    let filter = InnerLogFilter::new(&format!(
+    let filter = FilterConfig::new(&format!(
         "on[{}::{}], error",
         log_id.get_module_path(),
         log_id.get_identifier()

--- a/logid/src/macros.rs
+++ b/logid/src/macros.rs
@@ -116,30 +116,3 @@ macro_rules! pipe {
         }
     };
 }
-
-/// Helper macro for construction of a [`FilterConfig`] using custom short-hand syntax.
-///
-/// # Example
-/// ```
-/// # use logid::{log_id::LogLevel, logging::filter::AddonFilter};
-/// let (level, addon) = logid::filter!(Trace(AllAllowed));
-///
-/// assert_eq!(level, LogLevel::Trace);
-/// assert_eq!(addon, AddonFilter::AllAllowed);
-/// ```
-#[macro_export]
-macro_rules! filter {
-    ($level:ident($addon:ident)) => {
-        (
-            $crate::log_id::LogLevel::$level,
-            $crate::logging::filter::AddonFilter::$addon,
-        )
-    };
-
-    ($level:path { $addon:path } ) => {{
-        let level: $crate::log_id::LogLevel = $level;
-        let addon: $crate::logging::filter::AddonFilter = $addon;
-
-        (level, $addon)
-    }};
-}

--- a/logid/src/macros.rs
+++ b/logid/src/macros.rs
@@ -117,13 +117,29 @@ macro_rules! pipe {
     };
 }
 
+/// Helper macro for construction of a [`FilterConfig`] using custom short-hand syntax.
+///
+/// # Example
+/// ```
+/// # use logid::{log_id::LogLevel, logging::filter::AddonFilter};
+/// let (level, addon) = logid::filter!(Trace(AllAllowed));
+///
+/// assert_eq!(level, LogLevel::Trace);
+/// assert_eq!(addon, AddonFilter::AllAllowed);
+/// ```
 #[macro_export]
-macro_rules! set_filter {
-    ($config:literal) => {{
-        if let Some(filter) = $crate::logging::LOGGER.get_filter() {
-            filter.set_filter($config)
-        } else {
-            Err($crate::logging::filter::FilterError::SettingFilter)
-        }
+macro_rules! filter {
+    ($level:ident($addon:ident)) => {
+        (
+            $crate::log_id::LogLevel::$level,
+            $crate::logging::filter::AddonFilter::$addon,
+        )
+    };
+
+    ($level:path { $addon:path } ) => {{
+        let level: $crate::log_id::LogLevel = $level;
+        let addon: $crate::logging::filter::AddonFilter = $addon;
+
+        (level, $addon)
     }};
 }

--- a/logid/tests/default_set_events.rs
+++ b/logid/tests/default_set_events.rs
@@ -17,20 +17,12 @@ enum TestErrId {
     Two,
 }
 
-#[derive(Debug, Default, logid_derive::TraceLogId, PartialEq, Clone, Error)]
-enum TraceTest {
-    #[error("Trace on `TraceTest::Trace`")]
-    #[default]
-    Trace,
-}
-
 #[test]
 fn capture_single_logid() {
     let msg = "Set first log message";
 
     let recv = LOGGER.subscribe(TestErrId::One.into()).unwrap();
 
-    log!(TraceTest::Trace, msg);
     log!(TestErrId::One, msg);
 
     let event = recv

--- a/logid/tests/default_set_events.rs
+++ b/logid/tests/default_set_events.rs
@@ -17,12 +17,20 @@ enum TestErrId {
     Two,
 }
 
+#[derive(Debug, Default, logid_derive::TraceLogId, PartialEq, Clone, Error)]
+enum TraceTest {
+    #[error("Trace on `TraceTest::Trace`")]
+    #[default]
+    Trace,
+}
+
 #[test]
 fn capture_single_logid() {
     let msg = "Set first log message";
 
     let recv = LOGGER.subscribe(TestErrId::One.into()).unwrap();
 
+    log!(TraceTest::Trace, msg);
     log!(TestErrId::One, msg);
 
     let event = recv


### PR DESCRIPTION
This PR aims to add support for builder pattern for logging filters. It is still possible to create filter from string. Ideally, it should be possible to construct filters fully using the builder pattern.

In this PR, ergonomic creation of some filters is made possible (LogLevel with AddonFilters), others might be implemented later. To extend the patterns, we simply need to implement `Into<FilterConfig>` for various types. 
To make it easier to add certain filters with builder pattern, the builder accepts iterators (`I: IntoIterator`) where items produced can be converted into corresponding filter (e.g. `I::Item: Into<LogIdAddonFilter>`). This is done so that we can come up with a short-hand version to create some filter (e.g. `LogIdAddonFilter`) the same way we create `FilterConfig` from `(LogLevel, AddonFilter)` tuple. 